### PR TITLE
Port argument is now a keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ import asyncio
 
 async def print_mac_address():
     # initialize the host
-    host = Host('192.168.1.109', 80, 'admin', 'admin1234')
+    host = Host('192.168.1.109','admin', 'admin1234', port=80)
     # connect and obtain/cache device settings and capabilities
     await host.get_host_data()
     # check if it is a camera or an NVR


### PR DESCRIPTION
Hi, thanks for your work on this library :-)

Was just setting it up and tried the example from the readme. It seems that my camera 510wa just return 302 on port 80, so I wanted to change to port 443. However this did not have any effect, and I could see in the error that it stilled tried to connect to port 80.

After some digging in the source code it seems that port should be the 4th argument, not the second as it is now.

cheers