### PR TITLE
Add RLC-812A to floodlight override list

### DIFF
--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -74,6 +74,7 @@ DUAL_LENS_MODELS: set[str] = {
 FLOODLIGHT_MODELS: set[str] = {
     "Reolink TrackMix PoE",
     "Reolink TrackMix WiFi",
+    "RLC-812A",
 }
 
 


### PR DESCRIPTION
Thanks for all the work on this and in HA!

Just a small contribution: my [RLC-812A](https://reolink.com/gb/product/rlc-812a/) also misreports the floodlight capability. I've tested the `WhiteLed` API commands with it and they seem to work ok, just the floodlight capability is missing.