### PR TITLE
Raise original exception on login failure

### DIFF
--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -4106,7 +4106,7 @@ class Host:
                     await self.expire_session()
                     return await self.send(body, param, expected_response_type, retry)
 
-            if response.status == 300:
+            if is_login_logout and response.status == 300:
                 response.release()
                 raise ApiError(f"API returned HTTP status ERROR code {response.status}/{response.reason}. " +
                                 "This may happen if you use HTTP and the camera expects HTTPS")

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -932,7 +932,7 @@ class Host:
         self.enable_https(False)
         try:
             await self.login()
-        except Exception:  # pylint: disable=bare-except
+        except LoginError:
             # Raise original exception instead of the retry fallback exception
             raise first_exc
 

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -928,9 +928,9 @@ class Host:
         except LoginError as exc:
             first_exc = exc
 
+        self._port = 80
+        self.enable_https(False)
         try:
-            self._port = 80
-            self.enable_https(False)
             await self.login()
         except Exception:  # pylint: disable=bare-except
             # Raise original exception instead of the retry fallback exception

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -4108,8 +4108,7 @@ class Host:
 
             if is_login_logout and response.status == 300:
                 response.release()
-                raise ApiError(f"API returned HTTP status ERROR code {response.status}/{response.reason}. " +
-                                "This may happen if you use HTTP and the camera expects HTTPS")
+                raise ApiError(f"API returned HTTP status ERROR code {response.status}/{response.reason}, this may happen if you use HTTP and the camera expects HTTPS")
 
             if response.status == 502 and retry > 0:
                 _LOGGER.debug("Host %s:%s: 502/Bad Gateway response, trying to login again and retry the command.", self._host, self._port)

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -932,9 +932,9 @@ class Host:
         self.enable_https(False)
         try:
             await self.login()
-        except LoginError:
+        except LoginError as exc:
             # Raise original exception instead of the retry fallback exception
-            raise first_exc
+            raise first_exc from exc
 
     async def logout(self, login_mutex_owned=False):
         body = [{"cmd": "Logout", "action": 0, "param": {}}]


### PR DESCRIPTION
The current implementation retries to login in http mode when https login fails. If http login fails too, then it will raise the exception of the retry attempt, masking the original error. This change raises the https loging exception when this operation fails (unless the http login succeeds) and instead masks the retry exception, if it happens.