### PR TITLE
Enable webhook usage through external application

### DIFF
--- a/examples/reolink_onvif_subscription/README.md
+++ b/examples/reolink_onvif_subscription/README.md
@@ -1,0 +1,32 @@
+# Reolink ONVIF subscription example
+
+This example shows how to point a Reolink camera to a webhook endpoint to receive ONVIF events, and how to parse those events.
+
+# Dependencies
+
+To run these examples you'll need the following dependencies:
+
+```
+python3 -m pipenv install flask aiohttp orjson typing_extensions
+```
+
+# Running
+
+First start the webhook_cat.py service:
+
+```
+python3 -m pipenv run python ./webhook_cat.py
+```
+
+This will start a Flask service, which will listen to all incoming messages in port 1234 in all available interfaces. When a message is received, it will try to parse it as a Reolink ONVIF message (or fail misserably).
+
+Take note of the interface and port in which webhook_cat is listening, and make sure your camera can access this URI.
+
+Next, configure the camera to use the webhook_cat service:
+
+```
+python3 -m pipenv run python ./trigger_subscription.py CAM_HOST CAM_USER CAM_PASS WEBHOOK_CAT_URI
+```
+
+If everything worked, webhook_cat should now be printing notifications from your camera.
+

--- a/examples/reolink_onvif_subscription/trigger_subscription.py
+++ b/examples/reolink_onvif_subscription/trigger_subscription.py
@@ -1,0 +1,63 @@
+import signal
+import time
+import asyncio
+import sys
+
+sys.path.append('../../')
+
+from reolink_aio.api import Host
+
+import logging
+logging.getLogger("reolink_aio.helpers").setLevel(logging.ERROR)
+
+if len(sys.argv) != 5:
+    print(f"Usage: {sys.argv[0]} CAM_HOST CAM_USER CAM_PASS WEBHOOK_URL")
+    print("\tCAM_HOST: The IP of your camera in your LAN")
+    print("\tCAM_USER: User name you use to login in the web interface")
+    print("\tCAM_PASS: Pass for CAM_USER. Use '' for blank password")
+    print("\tWEBHOOK_URL: A URL reachable by the camera. In this example, it should be the")
+    print("\t  list URI of webhook_cat.py")
+    print("\t  EG: 'http://192.168.1.20:1234/webhook'")
+    exit(1)
+
+CAM_HOST=sys.argv[1]
+CAM_USER=sys.argv[2]
+CAM_PASS=sys.argv[3]
+WEBHOOK_URL=sys.argv[4]
+
+
+gUserExitRq = False
+def on_signal(*args):
+    global gUserExitRq
+    print("User requested exit, cleanup...")
+    gUserExitRq = True
+signal.signal(signal.SIGINT, on_signal)
+signal.signal(signal.SIGTERM, on_signal)
+
+
+async def main():
+    host = Host(CAM_HOST, CAM_USER, CAM_PASS, use_https=True)
+
+    # Obtain/cache NVR or camera settings and capabilities, like model name, ports, HDD size, etc:
+    await host.get_host_data()
+
+    # Obtain/cache states of features:
+    await host.get_states()
+
+    print("Connected to camera", host.camera_name(0))
+
+    await host.subscribe(WEBHOOK_URL)
+    print(f"Subscribed to {WEBHOOK_URL}")
+
+    global gUserExitRq
+    while not gUserExitRq:
+        t = host.renewtimer()
+        print("Subscription seconds remaining: ", t)
+        if (t <= 100):
+            await host.renew()
+        time.sleep(1)
+
+    await host.unsubscribe()
+    await host.logout()
+
+asyncio.run(main())

--- a/examples/reolink_onvif_subscription/webhook_cat.py
+++ b/examples/reolink_onvif_subscription/webhook_cat.py
@@ -1,0 +1,23 @@
+from flask import Flask
+from flask import request as FlaskRequest
+
+import sys
+sys.path.append('../../')
+
+from reolink_aio.helpers import parse_reolink_onvif_event
+
+import logging
+logging.getLogger("reolink_aio.helpers").setLevel(logging.ERROR)
+
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
+app = Flask(__name__)
+
+@app.route('/', defaults={'path': ''}, methods=['GET', 'POST'])
+@app.route('/<path:path>', methods=['GET', 'POST'])
+def catch_all(path):
+    print(parse_reolink_onvif_event(FlaskRequest.data))
+    return '', 200
+
+app.run(port=1234, host='0.0.0.0', debug=True)

--- a/reolink_aio/helpers.py
+++ b/reolink_aio/helpers.py
@@ -1,0 +1,90 @@
+import logging
+from os.path import basename
+from typing import TypeAlias, Dict
+
+from xml.etree import ElementTree as XML
+
+_LOGGER = logging.getLogger(__name__)
+
+"""
+Channel is either the channel selected by the user, or the channel reported by the message.
+If not user sleected, the channel should be an int (in the normal case), or a string (the message
+specified a channel that coudldn't be parsed) or None (the message specified no channel)
+"""
+Channel: TypeAlias = int|str|None
+
+"""
+EventName is the event name reported by the message. These should be FaceDetect, Motion, 
+MotionAlarm, etc, however no validation is performed on the event names and these will
+contain whatever was sent by the camera.
+"""
+EventName: TypeAlias = bool|None
+
+"""
+State: True (active), False (inactive) or None (failed to parse message)
+"""
+EventState: TypeAlias = bool|None
+
+"""
+A map of all events parsed in a message (valid or invalid)
+"""
+EventsMap: TypeAlias = Dict[Channel, Dict[EventName, EventState]]
+
+
+def parse_reolink_onvif_event(
+        data: str,
+        root: XML.Element | None = None,
+        user_selected_channel: int | None = None
+    ) -> EventsMap:
+    """ Parses a webhook message received from a Reolink event subscription. If user_selected_channel
+    is specified, all events will assume to be for that channel, and no channel checking will be
+    performed. """
+
+    parsed_events: EventsMap = {}
+
+    if root is None:
+        root = XML.fromstring(data)
+
+    for message in root.iter("{http://docs.oasis-open.org/wsn/b-2}NotificationMessage"):
+        channel = user_selected_channel
+
+        # find NotificationMessage Rule (type of event)
+        topic_element = message.find("{http://docs.oasis-open.org/wsn/b-2}Topic[@Dialect='http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet']")
+        if topic_element is None or topic_element.text is None:
+            continue
+        rule = basename(topic_element.text)
+        if not rule:
+            continue
+
+        # find camera channel if not specified by caller
+        if channel is None:
+            source_element = message.find(".//{http://www.onvif.org/ver10/schema}SimpleItem[@Name='Source']")
+            if source_element is None:
+                source_element = message.find(".//{http://www.onvif.org/ver10/schema}SimpleItem[@Name='VideoSourceConfigurationToken']")
+            if source_element is not None and "Value" in source_element.attrib:
+                try:
+                    channel = int(source_element.attrib["Value"])
+                except ValueError:
+                    _LOGGER.warning("Reolink ONVIF event '%s' data contained invalid channel '%s'", rule, source_element.attrib["Value"])
+                    channel = str(source_element.attrib["Value"])
+            else:
+                _LOGGER.warning("Reolink ONVIF event '%s' does not contain channel", rule)
+
+        # find event state
+        key = "State"
+        if rule == "Motion":
+            key = "IsMotion"
+        data_element = message.find(f".//\u007bhttp://www.onvif.org/ver10/schema\u007dSimpleItem[@Name='{key}']")
+        if data_element is None or "Value" not in data_element.attrib:
+            _LOGGER.warning("ONVIF event '%s' did not contain data:\n%s", rule, data)
+            state = None
+        else:
+            state = data_element.attrib["Value"] == "true"
+
+        _LOGGER.info("Reolink ONVIF event channel %s, %s: %s", channel, rule, state)
+        if channel not in parsed_events:
+            parsed_events[channel] = {}
+        parsed_events[channel][rule] = state
+
+    return parsed_events
+


### PR DESCRIPTION
The current API doesn't expose a way to parse an ONVIF message from the
camera directly, without managing the connection itself. This makes it
harder to:

* implement a webhook in a different service, and have reolink_aio API
  only manage the state of the camera
* have visibility into the state of the camera, and its messages, from
  an outside service

This commit [PR] introduces a helper class that can parse a Reolink ONVIF
message into a somewhat self-descriptive Python dictionary. This helper
can be used from reolink_aio itself, or from a 3p application that only
needs to parse Reolink ONVIF messages.

This PR also includes an example of how to use reolink_aio to manage camera subscriptions with a
webhook to an external server.