### PR TITLE
Add ptzType == 6, which means supporting only p,t.

### DIFF
--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -1823,7 +1823,7 @@ class Host:
                         self._capabilities[channel].add("focus")
                         if self.api_version("disableAutoFocus", channel) > 0 and channel in self._auto_focus_settings:
                             self._capabilities[channel].add("auto_focus")
-                if ptz_ver in [2, 3, 5]:
+                if ptz_ver in [2, 3, 5, 6]:
                     self._capabilities[channel].add("tilt")
                 if ptz_ver in [2, 3, 5, 6, 7]:
                     self._capabilities[channel].add("pan_tilt")

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -1825,7 +1825,7 @@ class Host:
                             self._capabilities[channel].add("auto_focus")
                 if ptz_ver in [2, 3, 5]:
                     self._capabilities[channel].add("tilt")
-                if ptz_ver in [2, 3, 5, 7]:
+                if ptz_ver in [2, 3, 5, 6, 7]:
                     self._capabilities[channel].add("pan_tilt")
                     self._capabilities[channel].add("pan")
                     if self.api_version("ptzPreset", channel) > 0:

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -1423,9 +1423,9 @@ class Baichuan:
             ptz_ver = self.api_version("ptzType", channel)
             if ptz_ver != 0:
                 self.capabilities[channel].add("ptz")
-                if ptz_ver in [2, 3, 5]:
+                if ptz_ver in [2, 3, 5, 6]:
                     self.capabilities[channel].add("tilt")
-                if ptz_ver in [2, 3, 5, 7]:
+                if ptz_ver in [2, 3, 5, 6, 7]:
                     self.capabilities[channel].add("pan_tilt")
                     self.capabilities[channel].add("pan")
                     if self.api_version("ptzPreset", channel) > 0:


### PR DESCRIPTION
Argus PT sends ptzType==6 and supports pt.