### PR TITLE
Add 3D zoom (area zoom) support via Set3DPos/Get3DPos

### DIFF
--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -284,6 +284,7 @@ class Host:
         self._ptz_patrol_settings: dict[int, dict] = {}
         self._ptz_guard_settings: dict[int, dict] = {}
         self._ptz_position: dict[int, dict] = {}
+        self._ptz_3d_zoom_range: dict[int, dict] = {}
         self._email_settings: dict[int, dict] = {}
         self._ir_settings: dict[int, dict] = {}
         self._status_led_settings: dict[int, dict] = {}
@@ -1852,6 +1853,9 @@ class Host:
                     if warnings:
                         _LOGGER.debug("Camera %s reported to support zoom, but zoom range not available", self.camera_name(channel))
 
+            if self.api_version("supportPtz3DLocation", channel) > 0:
+                self._capabilities[channel].add("ptz_3d_zoom")
+
             if self.api_version("aiTrack", channel) > 0:
                 self._capabilities[channel].add("auto_track")
                 track_method = self._auto_track_range.get(channel, {}).get("aiTrack", False)
@@ -2002,6 +2006,8 @@ class Host:
                 ch_body = [{"cmd": "GetPtzGuard", "action": 0, "param": {"channel": channel}}]
             elif cmd == "GetPtzCurPos" and self.supported(channel, "ptz_position"):
                 ch_body = [{"cmd": "GetPtzCurPos", "action": 0, "param": {"PtzCurPos": {"channel": channel}}}]
+            elif cmd == "Get3DPos" and self.supported(channel, "ptz_3d_zoom"):
+                ch_body = [{"cmd": "Get3DPos", "action": 1, "param": {"channel": channel}}]
             elif cmd == "GetAiCfg" and self.supported(channel, "auto_track"):
                 ch_body = [{"cmd": "GetAiCfg", "action": 0, "param": {"channel": channel}}]
             elif cmd == "GetPtzTraceSection" and self.supported(channel, "auto_track_limit"):
@@ -2479,6 +2485,8 @@ class Host:
                 ch_body.append({"cmd": "GetPtzPreset", "action": 0, "param": {"channel": channel}})
                 ch_body.append({"cmd": "GetPtzPatrol", "action": 0, "param": {"channel": channel}})
                 ch_body.append({"cmd": "GetPtzGuard", "action": 0, "param": {"channel": channel}})
+            if self.supported(channel, "ptz_3d_zoom"):
+                ch_body.append({"cmd": "Get3DPos", "action": 1, "param": {"channel": channel}})
             if self.supported(channel, "auto_track"):
                 ch_body.append({"cmd": "GetAiCfg", "action": 1, "param": {"channel": channel}})
             if self.api_version("mask", channel) > 0 or self.supported(channel, "privacy_mask_basic"):
@@ -4117,6 +4125,9 @@ class Host:
                 elif data["cmd"] == "GetAutoFocus":
                     self._auto_focus_settings[channel] = data["value"]["AutoFocus"]
 
+                elif data["cmd"] == "Get3DPos":
+                    self._ptz_3d_zoom_range[channel] = data["value"]["3d_pos"]
+
                 elif data["cmd"] == "GetZoomFocus":
                     zoom = self._zoom_focus_settings.setdefault(channel, {}).setdefault("zoom", {})
                     focus = self._zoom_focus_settings[channel].setdefault("focus", {})
@@ -4422,6 +4433,85 @@ class Host:
         ]
 
         await self.send_setting(body, getcmd="GetZoomFocus", wait_before_get=3)
+
+    def ptz_3d_zoom_range(self, channel: int) -> dict:
+        """Get the stream resolutions for 3D zoom (from Get3DPos).
+
+        Returns dict with mainStream/subStream/extStream, each containing width/height.
+        These values are used as the width/height parameters when calling set_ptz_3d_zoom.
+        """
+        if channel not in self._channels:
+            raise InvalidParameterError(f"ptz_3d_zoom_range: no camera connected to channel '{channel}'")
+        if not self.supported(channel, "ptz_3d_zoom"):
+            raise NotSupportedError(f"ptz_3d_zoom_range: 3D zoom on camera {self.camera_name(channel)} is not available")
+
+        return self._ptz_3d_zoom_range.get(channel, {})
+
+    async def set_ptz_3d_zoom(
+        self,
+        channel: int,
+        pos_x: int,
+        pos_y: int,
+        pos_width: int,
+        pos_height: int,
+        stream_width: int | None = None,
+        stream_height: int | None = None,
+        speed: int = 20,
+    ) -> None:
+        """Send a 3D zoom (area zoom) command to the PTZ camera.
+
+        The camera will pan, tilt, and zoom in a single motion to frame the specified rectangle.
+
+        Parameters:
+        pos_x (int): X coordinate of the center of the zoom box, in stream pixel coordinates.
+        pos_y (int): Y coordinate of the center of the zoom box, in stream pixel coordinates.
+        pos_width (int): Width of the zoom box in pixels. Smaller values = more zoom.
+        pos_height (int): Height of the zoom box in pixels. Smaller values = more zoom.
+        stream_width (int): Width of the video stream (default: mainStream width from Get3DPos).
+        stream_height (int): Height of the video stream (default: mainStream height from Get3DPos).
+        speed (int): Movement speed, 1-64 (default: 20).
+        """
+        if channel not in self._channels:
+            raise InvalidParameterError(f"set_ptz_3d_zoom: no camera connected to channel '{channel}'")
+        if not self.supported(channel, "ptz_3d_zoom"):
+            raise NotSupportedError(f"set_ptz_3d_zoom: 3D zoom on camera {self.camera_name(channel)} is not available")
+
+        if stream_width is None or stream_height is None:
+            range_data = self._ptz_3d_zoom_range.get(channel, {})
+            main_stream = range_data.get("mainStream", {})
+            if stream_width is None:
+                stream_width = main_stream.get("width")
+            if stream_height is None:
+                stream_height = main_stream.get("height")
+            if stream_width is None or stream_height is None:
+                raise InvalidParameterError(
+                    f"set_ptz_3d_zoom: stream resolution not available for camera {self.camera_name(channel)}, "
+                    "provide stream_width and stream_height explicitly"
+                )
+
+        if not 1 <= speed <= 64:
+            raise InvalidParameterError(f"set_ptz_3d_zoom: speed {speed} not in range 1..64")
+
+        body: typings.reolink_json = [
+            {
+                "cmd": "Set3DPos",
+                "action": 0,
+                "param": {
+                    "3DPos": {
+                        "channel": channel,
+                        "posX": pos_x,
+                        "posY": pos_y,
+                        "posWidth": pos_width,
+                        "posHeight": pos_height,
+                        "speed": speed,
+                        "width": stream_width,
+                        "height": stream_height,
+                    }
+                },
+            }
+        ]
+
+        await self.send_setting(body)
 
     def ptz_presets(self, channel: int) -> dict:
         if channel not in self._ptz_presets:

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -1853,7 +1853,7 @@ class Host:
                     if warnings:
                         _LOGGER.debug("Camera %s reported to support zoom, but zoom range not available", self.camera_name(channel))
 
-            if self.api_version("supportPtz3DLocation", channel) > 0:
+            if ptz_ver != 0 and not self.baichuan_only and self.api_version("supportPtz3DLocation", channel) > 0:
                 self._capabilities[channel].add("ptz_3d_zoom")
 
             if self.api_version("aiTrack", channel) > 0:
@@ -4489,6 +4489,15 @@ class Host:
                     "provide stream_width and stream_height explicitly"
                 )
 
+        for name, val in [("pos_x", pos_x), ("pos_y", pos_y), ("pos_width", pos_width), ("pos_height", pos_height)]:
+            if not isinstance(val, int):
+                raise InvalidParameterError(f"set_ptz_3d_zoom: {name} value {val} is not an integer")
+        if pos_width <= 0 or pos_height <= 0:
+            raise InvalidParameterError(f"set_ptz_3d_zoom: pos_width ({pos_width}) and pos_height ({pos_height}) must be positive")
+        if not (0 <= pos_x <= stream_width):
+            raise InvalidParameterError(f"set_ptz_3d_zoom: pos_x ({pos_x}) out of range 0..{stream_width}")
+        if not (0 <= pos_y <= stream_height):
+            raise InvalidParameterError(f"set_ptz_3d_zoom: pos_y ({pos_y}) out of range 0..{stream_height}")
         if not 1 <= speed <= 64:
             raise InvalidParameterError(f"set_ptz_3d_zoom: speed {speed} not in range 1..64")
 

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -1853,7 +1853,7 @@ class Host:
                     if warnings:
                         _LOGGER.debug("Camera %s reported to support zoom, but zoom range not available", self.camera_name(channel))
 
-            if ptz_ver != 0 and not self.baichuan_only and self.api_version("supportPtz3DLocation", channel) > 0:
+            if ptz_ver != 0 and self.api_version("supportPtz3DLocation", channel) > 0:
                 self._capabilities[channel].add("ptz_3d_zoom")
 
             if self.api_version("aiTrack", channel) > 0:

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -4484,8 +4484,7 @@ class Host:
                 stream_height = main_stream.get("height")
             if stream_width is None or stream_height is None:
                 raise InvalidParameterError(
-                    f"set_ptz_3d_zoom: stream resolution not available for camera {self.camera_name(channel)}, "
-                    "provide stream_width and stream_height explicitly"
+                    f"set_ptz_3d_zoom: stream resolution not available for camera {self.camera_name(channel)}, provide stream_width and stream_height explicitly"
                 )
 
         for name, val in [("pos_x", pos_x), ("pos_y", pos_y), ("pos_width", pos_width), ("pos_height", pos_height)]:
@@ -4493,9 +4492,9 @@ class Host:
                 raise InvalidParameterError(f"set_ptz_3d_zoom: {name} value {val} is not an integer")
         if pos_width <= 0 or pos_height <= 0:
             raise InvalidParameterError(f"set_ptz_3d_zoom: pos_width ({pos_width}) and pos_height ({pos_height}) must be positive")
-        if not (0 <= pos_x <= stream_width):
+        if pos_x < 0 or pos_x > stream_width:
             raise InvalidParameterError(f"set_ptz_3d_zoom: pos_x ({pos_x}) out of range 0..{stream_width}")
-        if not (0 <= pos_y <= stream_height):
+        if pos_y < 0 or pos_y > stream_height:
             raise InvalidParameterError(f"set_ptz_3d_zoom: pos_y ({pos_y}) out of range 0..{stream_height}")
         if not 1 <= speed <= 64:
             raise InvalidParameterError(f"set_ptz_3d_zoom: speed {speed} not in range 1..64")

--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -1824,6 +1824,8 @@ class Host:
                         self._capabilities[channel].add("focus")
                         if self.api_version("disableAutoFocus", channel) > 0 and channel in self._auto_focus_settings:
                             self._capabilities[channel].add("auto_focus")
+                    if self.api_version("supportPtz3DLocation", channel) > 0:
+                        self._capabilities[channel].add("ptz_3d_zoom")
                 if ptz_ver in [2, 3, 5, 6]:
                     self._capabilities[channel].add("tilt")
                 if ptz_ver in [2, 3, 5, 6, 7]:
@@ -1852,9 +1854,6 @@ class Host:
                 else:
                     if warnings:
                         _LOGGER.debug("Camera %s reported to support zoom, but zoom range not available", self.camera_name(channel))
-
-            if ptz_ver != 0 and self.api_version("supportPtz3DLocation", channel) > 0:
-                self._capabilities[channel].add("ptz_3d_zoom")
 
             if self.api_version("aiTrack", channel) > 0:
                 self._capabilities[channel].add("auto_track")

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -2311,10 +2311,11 @@ class Baichuan:
         self._ptz_patrol_cruising[channel] = cruising
 
     @http_cmd("Set3DPos")
-    async def set_ptz_3d_zoom(self, channel: int, **kwargs) -> None:
-        params = kwargs.get("3DPos", {})
-        xml = xmls.Ptz3DZoom.format(
-            channel=params.get("channel", channel),
+    async def set_ptz_3d_zoom(self, **kwargs) -> None:
+        params = kwargs.get("3DPos", kwargs)
+        channel = params.get("channel", 0)
+        xml = xmls.Ptz3DLocation.format(
+            channel=channel,
             pos_x=params["posX"],
             pos_y=params["posY"],
             pos_width=params["posWidth"],

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -1444,6 +1444,9 @@ class Baichuan:
                     if (ptz_ctr >> 6) & 1:  # 7th bit (64), shift 6
                         self.capabilities[channel].add("ptz_speed")
 
+                if self.api_version("supportPtz3DLocation", channel) > 0:
+                    self.capabilities[channel].add("ptz_3d_zoom")
+
 
     async def get_channel_data(self) -> None:
         """Fetch the channel settings/capabilities."""

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -1444,6 +1444,9 @@ class Baichuan:
                     if (ptz_ctr >> 6) & 1:  # 7th bit (64), shift 6
                         self.capabilities[channel].add("ptz_speed")
 
+                if self.api_version("supportPtz3DLocation", channel) > 0:
+                    self.capabilities[channel].add("ptz_3d_zoom")
+
     async def get_channel_data(self) -> None:
         """Fetch the channel settings/capabilities."""
         # Stream capabilities

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -2310,6 +2310,21 @@ class Baichuan:
             cruising = cruising or cruise.text == "1"
         self._ptz_patrol_cruising[channel] = cruising
 
+    @http_cmd("Set3DPos")
+    async def set_ptz_3d_zoom(self, channel: int, **kwargs) -> None:
+        params = kwargs.get("3DPos", {})
+        xml = xmls.Ptz3DZoom.format(
+            channel=params.get("channel", channel),
+            pos_x=params["posX"],
+            pos_y=params["posY"],
+            pos_width=params["posWidth"],
+            pos_height=params["posHeight"],
+            speed=params.get("speed", 20),
+            width=params["width"],
+            height=params["height"],
+        )
+        await self.send(cmd_id=445, channel=channel, body=xml)
+
     @http_cmd("PtzCheck")
     async def ptz_callibrate(self, channel: int) -> None:
         await self.send(cmd_id=341, channel=channel)

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -1444,8 +1444,6 @@ class Baichuan:
                     if (ptz_ctr >> 6) & 1:  # 7th bit (64), shift 6
                         self.capabilities[channel].add("ptz_speed")
 
-                if self.api_version("supportPtz3DLocation", channel) > 0:
-                    self.capabilities[channel].add("ptz_3d_zoom")
 
     async def get_channel_data(self) -> None:
         """Fetch the channel settings/capabilities."""

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -1424,6 +1424,9 @@ class Baichuan:
             ptz_ver = self.api_version("ptzType", channel)
             if ptz_ver != 0:
                 self.capabilities[channel].add("ptz")
+                if ptz_ver in [1, 2, 5]:
+                    if self.api_version("supportPtz3DLocation", channel) > 0:
+                        self.capabilities[channel].add("ptz_3d_zoom")
                 if ptz_ver in [2, 3, 5, 6]:
                     self.capabilities[channel].add("tilt")
                 if ptz_ver in [2, 3, 5, 6, 7]:
@@ -1443,10 +1446,6 @@ class Baichuan:
                         self.capabilities[channel].add("ptz_callibrate")
                     if (ptz_ctr >> 6) & 1:  # 7th bit (64), shift 6
                         self.capabilities[channel].add("ptz_speed")
-
-                if self.api_version("supportPtz3DLocation", channel) > 0:
-                    self.capabilities[channel].add("ptz_3d_zoom")
-
 
     async def get_channel_data(self) -> None:
         """Fetch the channel settings/capabilities."""

--- a/reolink_aio/baichuan/xmls.py
+++ b/reolink_aio/baichuan/xmls.py
@@ -451,6 +451,21 @@ PtzPreset = """
 </PtzPreset>
 </body>"""
 
+Ptz3DZoom = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<Ptz3DZoom version="1.1">
+<channelId>{channel}</channelId>
+<posX>{pos_x}</posX>
+<posY>{pos_y}</posY>
+<posWidth>{pos_width}</posWidth>
+<posHeight>{pos_height}</posHeight>
+<speed>{speed}</speed>
+<width>{width}</width>
+<height>{height}</height>
+</Ptz3DZoom>
+</body>"""
+
 PtzGuard = """
 <?xml version="1.0" encoding="UTF-8" ?>
 <body>

--- a/reolink_aio/baichuan/xmls.py
+++ b/reolink_aio/baichuan/xmls.py
@@ -451,10 +451,10 @@ PtzPreset = """
 </PtzPreset>
 </body>"""
 
-Ptz3DZoom = """
+Ptz3DLocation = """
 <?xml version="1.0" encoding="UTF-8" ?>
 <body>
-<Ptz3DZoom version="1.1">
+<Ptz3DLocation version="1.1">
 <channelId>{channel}</channelId>
 <posX>{pos_x}</posX>
 <posY>{pos_y}</posY>
@@ -463,7 +463,7 @@ Ptz3DZoom = """
 <speed>{speed}</speed>
 <width>{width}</width>
 <height>{height}</height>
-</Ptz3DZoom>
+</Ptz3DLocation>
 </body>"""
 
 PtzGuard = """


### PR DESCRIPTION
## Summary

- Adds support for Reolink's **3D zoom** (area zoom) feature, which pans, tilts, and zooms the camera to a specified rectangular region in a single smooth motion
- Detects capability via `supportPtz3DLocation` ability flag
- New methods: `ptz_3d_zoom_range()` and `set_ptz_3d_zoom()`

## API Details

**Discovery:** `Get3DPos` returns stream resolutions for coordinate mapping:
```json
{"cmd":"Get3DPos","action":1,"param":{"channel":0}}
```
Response: `{"3d_pos": {"channel": 0, "mainStream": {"width": 3840, "height": 2160}, "subStream": {...}, "extStream": {...}}}`

**3D Zoom command:** `Set3DPos` with a rectangle defined in stream pixel coordinates:
```json
{"cmd":"Set3DPos","action":0,"param":{"3DPos":{
  "channel": 0,
  "posX": 2880, "posY": 1080,
  "posWidth": 800, "posHeight": 600,
  "speed": 20,
  "width": 3840, "height": 2160
}}}
```

Parameters:
| Param | Description |
|-------|-------------|
| `posX`, `posY` | Center of the zoom box (stream pixel coords) |
| `posWidth`, `posHeight` | Size of the zoom box (smaller = more zoom) |
| `speed` | Movement speed (1-64) |
| `width`, `height` | Stream resolution (from Get3DPos) |

## How it was discovered

The Set3DPos command parameters were reverse-engineered by:
1. Identifying `supportPtz3DLocation` in the camera's `GetAbility` response
2. Intercepting Baichuan protocol traffic (cmd_id 445) from the Reolink mobile app
3. Cross-referencing with firmware JS (`ViewPtz3DLocation.js` from RLC-823A_16X firmware, as discussed in #10)
4. Testing and verifying against a live Reolink PTZ camera

Note: This feature is only available via Reolink's HTTP API. ONVIF does not expose it — Reolink PTZ cameras typically only report ContinuousMove support via ONVIF.

## Changes

- `reolink_aio/api.py`: Capability detection, response parsing, initial data fetch, and public getter/setter methods
- `reolink_aio/baichuan/baichuan.py`: Mirror capability detection for Baichuan connections

## Test plan

- [x] Verified `Get3DPos` returns correct stream resolutions
- [x] Verified `Set3DPos` successfully moves camera (pan + tilt + zoom in single motion)
- [x] Tested with multiple zoom box positions and sizes
- [ ] Needs testing on additional Reolink PTZ models

🤖 Generated with [Claude Code](https://claude.com/claude-code)