### PR TITLE
Add VOD file download over Baichuan

### DIFF
--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+import re
+from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timedelta
 from inspect import getmembers
 from time import time as time_now
@@ -82,6 +83,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+VOD_QUEUE_CHUNKS = 512
+
 KEEP_ALLIVE_INTERVAL = 30  # seconds
 MIN_KEEP_ALLIVE_INTERVAL = 9  # seconds
 BATTERY_CLOSE_TIME = 5  # seconds
@@ -144,6 +147,9 @@ class Baichuan:
         self._user_hash: str | None = None
         self._password_hash: str | None = None
         self._aes_key: bytes | None = None
+        self._vod_queue: asyncio.Queue[bytes] | None = None
+        self._vod_overflow: bool = False
+        self._vod_download_rejected: set[int] = set()
         self._log_once: set[str] = set()
         self._log_error: bool = True
         self.last_privacy_check: float = 0
@@ -878,6 +884,15 @@ class Baichuan:
             rec_set["schedule"]["channel"] = channel
             if self.http_api.api_version("GetRec") >= 1:
                 rec_set["scheduleEnable"] = enable
+
+        elif cmd_id == 8 and self._vod_queue is not None:  # VOD file download
+            if payload:
+                try:
+                    self._vod_queue.put_nowait(payload)
+                except asyncio.QueueFull:
+                    # dropping a chunk would corrupt the file, so end the transfer
+                    self._vod_overflow = True
+            return
 
         elif cmd_id in {109, 298}:  # 109=Snapshot, 298=CoverPreview
             if mess_id is None:
@@ -4218,6 +4233,88 @@ class Baichuan:
         # await self.send(cmd_id=16, body=xml_file_info)
 
         return vod_type_dict, vod_dict
+
+    @staticmethod
+    def _vod_name_element(file_id: str, channel: int) -> str:
+        """Build the <name> element older models need in addition to the <Id> path."""
+        match = re.search(r"Rec\w{3}(?:_DST|_)(\d{8})_(\d{6})_", file_id)
+        if match is None:
+            return ""
+        return f"\n<name>{channel + 1:02d}{match.group(1)}{match.group(2)}</name>"
+
+    async def get_vod_file_info(self, channel: int, file_id: str) -> dict[str, Any]:
+        """Get the size, handle and type of a recording file using cmd_id 13."""
+        if channel in self._vod_download_rejected:
+            raise NotSupportedError(f"Baichuan host {self._host}: camera refused to download recordings on channel {channel}")
+
+        name = self._vod_name_element(file_id, channel)
+        try:
+            mess = await self.send(cmd_id=13, body=xmls.VodFileInfo.format(file_id=file_id, channel=channel, name=name))
+        except ApiError as err:
+            if err.rspCode == 400:
+                self._vod_download_rejected.add(channel)
+            raise
+
+        size = (get_value_from_xml(mess, "sizeL", int) or 0) + ((get_value_from_xml(mess, "sizeH", int) or 0) << 32)
+        if not size:
+            raise UnexpectedDataError(f"Baichuan host {self._host}: no size reported for VOD file '{file_id}'")
+
+        return {
+            "size": size,
+            "handle": get_value_from_xml(mess, "handle") or "0",
+            "file_type": get_value_from_xml(mess, "fileType"),
+            "contains_audio": get_value_from_xml(mess, "containsAudio", bool) or False,
+        }
+
+    async def download_vod(
+        self,
+        channel: int,
+        file_id: str,
+        info: dict[str, Any] | None = None,
+        timeout: int = 60,
+    ) -> AsyncIterator[bytes]:
+        """Download a recording over Baichuan, yielding it chunk by chunk."""
+        if info is None:
+            info = await self.get_vod_file_info(channel, file_id)
+
+        if self._vod_queue is not None:
+            raise ReolinkError(f"Baichuan host {self._host}: a VOD download is already in progress")
+
+        size = info["size"]
+        received = 0
+        # bounded, so a consumer that cannot keep up fails instead of growing
+        # until it runs the host out of memory
+        queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=VOD_QUEUE_CHUNKS)
+        self._vod_queue = queue
+        self._vod_overflow = False
+
+        try:
+            body = xmls.VodFileDownload.format(file_id=file_id, channel=channel, name=self._vod_name_element(file_id, channel))
+            try:
+                await self.send(cmd_id=8, body=body)
+            except ApiError as err:
+                if err.rspCode == 400:
+                    self._vod_download_rejected.add(channel)
+                raise
+
+            # the camera sends no terminator, the transfer ends at the reported size
+            while received < size:
+                if self._vod_overflow:
+                    raise ReolinkError(f"Baichuan host {self._host}: VOD '{file_id}' arrived faster than it was consumed")
+                try:
+                    async with asyncio.timeout(timeout):
+                        chunk = await queue.get()
+                except asyncio.TimeoutError as err:
+                    raise ReolinkTimeoutError(f"Baichuan host {self._host}: timeout downloading VOD '{file_id}', received {received} of {size} bytes") from err
+                received += len(chunk)
+                yield chunk
+        finally:  # the camera only has one VOD session, always release it
+            self._vod_queue = None
+            self._vod_overflow = False
+            try:
+                await self.send(cmd_id=9, body=xmls.VodFileStop.format(channel=channel, handle=info["handle"]))
+            except ReolinkError as err:
+                _LOGGER.debug("Baichuan host %s: could not stop VOD download after %s bytes: %s", self._host, received, err)
 
     @property
     def events_active(self) -> bool:

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timedelta
 from inspect import getmembers
@@ -53,7 +52,7 @@ from ..exceptions import (
     UnexpectedDataError,
 )
 from ..software_version import SoftwareVersion
-from ..typings import VOD_file, VOD_trigger, cmd_list_type
+from ..typings import VOD_file, VOD_file_info, VOD_trigger, cmd_list_type, parse_file_name
 from ..utils import (
     datetime_to_reolink_time,
     reolink_time_to_datetime,
@@ -84,6 +83,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 VOD_QUEUE_CHUNKS = 512
+VOD_SEARCH_PAGES = 30
 
 KEEP_ALLIVE_INTERVAL = 30  # seconds
 MIN_KEEP_ALLIVE_INTERVAL = 9  # seconds
@@ -4235,55 +4235,153 @@ class Baichuan:
         return vod_type_dict, vod_dict
 
     @staticmethod
+    def _vod_name(channel: int, start: datetime) -> str:
+        """Build the name the camera lists a recording under."""
+        return f"{channel + 1:02d}{to_reolink_time_id(start)}"
+
+    @staticmethod
     def _vod_name_element(file_id: str, channel: int) -> str:
         """Build the <name> element older models need in addition to the <Id> path."""
-        match = re.search(r"Rec\w{3}(?:_DST|_)(\d{8})_(\d{6})_", file_id)
-        if match is None:
+        start = Baichuan._vod_start_time(file_id)
+        if start is None:
             return ""
-        return f"\n<name>{channel + 1:02d}{match.group(1)}{match.group(2)}</name>"
+        return f"\n<name>{Baichuan._vod_name(channel, start)}</name>"
 
-    async def get_vod_file_info(self, channel: int, file_id: str) -> dict[str, Any]:
-        """Get the size, handle and type of a recording file using cmd_id 13."""
+    @staticmethod
+    def _vod_start_time(file_id: str) -> datetime | None:
+        """Read the start time out of a recording file name."""
+        try:
+            parsed = parse_file_name(file_id)
+        except ValueError:
+            return None
+        if parsed is None:
+            return None
+        return datetime.combine(parsed.date, parsed.start)
+
+    async def _search_vod_file(self, channel: int, file_id: str, stream: str | None) -> VOD_file_info | None:
+        """Look a recording up by its start time, for the path the camera itself reports.
+
+        Returns None when the file name carries no usable start time.
+        """
+        start = self._vod_start_time(file_id)
+        if start is None:
+            return None
+
+        # the search only answers for the stream it is asked about, and only these
+        # two translate to what Baichuan calls them
+        if stream is None:
+            stream = "sub" if file_id.rsplit("/", 1)[-1].startswith("RecS") else "main"
+        if stream not in ["main", "sub"]:
+            return None
+        end = start + timedelta(seconds=1)
+        xml = xmls.VodFileSearchOpen.format(
+            channel=channel,
+            stream=f"{stream}Stream",
+            start_year=start.year,
+            start_month=start.month,
+            start_day=start.day,
+            start_hour=start.hour,
+            start_minute=start.minute,
+            start_second=start.second,
+            end_year=end.year,
+            end_month=end.month,
+            end_day=end.day,
+            end_hour=end.hour,
+            end_minute=end.minute,
+            end_second=end.second,
+        )
+        mess = await self.send(cmd_id=14, body=xml)
+        body: str | None = None
+        try:
+            body = xmls.VodFileSearchHandle.format(channel=channel, handle=get_value_from_xml(mess, "handle") or "0")
+            entries: list[XML.Element] = []
+            for _ in range(VOD_SEARCH_PAGES):
+                page = await self.send(cmd_id=15, body=body)
+                found = [item for item in XML.fromstring(page).findall(".//FileInfo") if item.find("Id") is not None]
+                entries.extend(found)
+                if not found:
+                    break
+        finally:
+            if body is not None:
+                try:
+                    await self.send(cmd_id=16, body=body)
+                except ReolinkError as err:
+                    _LOGGER.debug("Baichuan host %s: could not close VOD file search: %s", self._host, err)
+
+        name = self._vod_name(channel, start)
+        for entry in entries:
+            if get_value_from_xml(entry, "name") != name:
+                continue
+            size = (get_value_from_xml(entry, "sizeL", int) or 0) + ((get_value_from_xml(entry, "sizeH", int) or 0) << 32)
+            path = get_value_from_xml(entry, "Id")
+            if not size or not path:
+                return None
+            return VOD_file_info(
+                size=size,
+                handle="0",
+                file_id=path,
+                resolved=True,
+                file_type=get_value_from_xml(entry, "fileType"),
+                contains_audio=get_value_from_xml(entry, "containsAudio", bool) or False,
+            )
+        return None
+
+    async def get_vod_file_info(self, channel: int, file_id: str, stream: str | None = None) -> VOD_file_info:
+        """Get the size, path and type of a recording file.
+
+        The search is preferred because the camera reports the recording's own
+        path there, which is what the download needs; some models answer their
+        file list with an absolute path while asking for a relative one. It has
+        to be told which stream the recording belongs to, so pass the one the
+        file list was requested with; it is guessed from the file name if not.
+        """
         if channel in self._vod_download_rejected:
             raise NotSupportedError(f"Baichuan host {self._host}: camera refused to download recordings on channel {channel}")
 
-        name = self._vod_name_element(file_id, channel)
         try:
-            mess = await self.send(cmd_id=13, body=xmls.VodFileInfo.format(file_id=file_id, channel=channel, name=name))
-        except ApiError as err:
-            if err.rspCode == 400:
-                self._vod_download_rejected.add(channel)
-            raise
+            info = await self._search_vod_file(channel, file_id, stream)
+        except ReolinkError as err:
+            _LOGGER.debug("Baichuan host %s: could not search for VOD file '%s': %s", self._host, file_id, err)
+        else:
+            if info is not None:
+                return info
+
+        name = self._vod_name_element(file_id, channel)
+        mess = await self.send(cmd_id=13, body=xmls.VodFileInfo.format(file_id=file_id, channel=channel, name=name))
 
         size = (get_value_from_xml(mess, "sizeL", int) or 0) + ((get_value_from_xml(mess, "sizeH", int) or 0) << 32)
         if not size:
             raise UnexpectedDataError(f"Baichuan host {self._host}: no size reported for VOD file '{file_id}'")
 
-        return {
-            "size": size,
-            "handle": get_value_from_xml(mess, "handle") or "0",
-            "file_type": get_value_from_xml(mess, "fileType"),
-            "contains_audio": get_value_from_xml(mess, "containsAudio", bool) or False,
-        }
+        return VOD_file_info(
+            size=size,
+            handle=get_value_from_xml(mess, "handle") or "0",
+            file_id=file_id,
+            resolved=False,
+            file_type=get_value_from_xml(mess, "fileType"),
+            contains_audio=get_value_from_xml(mess, "containsAudio", bool) or False,
+        )
 
     async def download_vod(
         self,
         channel: int,
         file_id: str,
-        info: dict[str, Any] | None = None,
+        info: VOD_file_info | None = None,
         timeout: int = 60,
     ) -> AsyncIterator[bytes]:
         """Download a recording over Baichuan, yielding it chunk by chunk."""
         if info is None:
             info = await self.get_vod_file_info(channel, file_id)
 
+        # the camera reports its own path, not always the one the caller was given
+        file_id = info.file_id or file_id
+
         if self._vod_queue is not None:
             raise ReolinkError(f"Baichuan host {self._host}: a VOD download is already in progress")
 
-        size = info["size"]
+        size = info.size
         received = 0
-        # bounded, so a consumer that cannot keep up fails instead of growing
-        # until it runs the host out of memory
+        # bounded, so a slow consumer fails instead of exhausting memory
         queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=VOD_QUEUE_CHUNKS)
         self._vod_queue = queue
         self._vod_overflow = False
@@ -4293,7 +4391,8 @@ class Baichuan:
             try:
                 await self.send(cmd_id=8, body=body)
             except ApiError as err:
-                if err.rspCode == 400:
+                # only a refusal of the camera's own path says anything about it
+                if err.rspCode == 400 and info.resolved:
                     self._vod_download_rejected.add(channel)
                 raise
 
@@ -4312,7 +4411,7 @@ class Baichuan:
             self._vod_queue = None
             self._vod_overflow = False
             try:
-                await self.send(cmd_id=9, body=xmls.VodFileStop.format(channel=channel, handle=info["handle"]))
+                await self.send(cmd_id=9, body=xmls.VodFileStop.format(channel=channel, handle=info.handle))
             except ReolinkError as err:
                 _LOGGER.debug("Baichuan host %s: could not stop VOD download after %s bytes: %s", self._host, received, err)
 

--- a/reolink_aio/baichuan/xmls.py
+++ b/reolink_aio/baichuan/xmls.py
@@ -278,6 +278,39 @@ FileInfoList = """
 </FileInfoList>
 </body>"""
 
+VodFileInfo = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<FileInfoList version="1.1">
+<FileInfo>
+<Id>{file_id}</Id>
+<channelId>{channel}</channelId>{name}
+</FileInfo>
+</FileInfoList>
+</body>"""
+
+VodFileDownload = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<FileInfoList version="1.1">
+<FileInfo>
+<Id>{file_id}</Id>
+<channelId>{channel}</channelId>{name}
+</FileInfo>
+</FileInfoList>
+</body>"""
+
+VodFileStop = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<FileInfoList version="1.1">
+<FileInfo>
+<channelId>{channel}</channelId>
+<handle>{handle}</handle>
+</FileInfo>
+</FileInfoList>
+</body>"""
+
 FindRecVideoOpen = """
 <?xml version="1.0" encoding="UTF-8" ?>
 <body>

--- a/reolink_aio/baichuan/xmls.py
+++ b/reolink_aio/baichuan/xmls.py
@@ -300,6 +300,46 @@ VodFileDownload = """
 </FileInfoList>
 </body>"""
 
+VodFileSearchOpen = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<FileInfoList version="1.1">
+<FileInfo>
+<searchAITrack>1</searchAITrack>
+<channelId>{channel}</channelId>
+<streamType>{stream}</streamType>
+<startTime>
+<year>{start_year}</year>
+<month>{start_month}</month>
+<day>{start_day}</day>
+<hour>{start_hour}</hour>
+<minute>{start_minute}</minute>
+<second>{start_second}</second>
+</startTime>
+<endTime>
+<year>{end_year}</year>
+<month>{end_month}</month>
+<day>{end_day}</day>
+<hour>{end_hour}</hour>
+<minute>{end_minute}</minute>
+<second>{end_second}</second>
+</endTime>
+</FileInfo>
+</FileInfoList>
+</body>"""
+
+VodFileSearchHandle = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<FileInfoList version="1.1">
+<FileInfo>
+<channelId>{channel}</channelId>
+<searchAITrack>1</searchAITrack>
+<handle>{handle}</handle>
+</FileInfo>
+</FileInfoList>
+</body>"""
+
 VodFileStop = """
 <?xml version="1.0" encoding="UTF-8" ?>
 <body>

--- a/reolink_aio/typings.py
+++ b/reolink_aio/typings.py
@@ -324,6 +324,18 @@ Parsed_VOD_file_name = NamedTuple(
     ],
 )
 
+VOD_file_info = NamedTuple(
+    "VOD_file_info",
+    [
+        ("size", int),
+        ("handle", str),
+        ("file_id", str),
+        ("resolved", bool),
+        ("file_type", Optional[str]),
+        ("contains_audio", bool),
+    ],
+)
+
 VOD_download = NamedTuple(
     "VOD_download",
     [


### PR DESCRIPTION
## Description

Adds `get_vod_file_info()` and `download_vod()` to the Baichuan client, so a
recording can be fetched over the Baichuan connection instead of the HTTP
`cmd=Playback` / `cmd=Download` handler. The sequence follows what Reolink's own
CLI does against my cameras: a file search for the recording, then the download.
`download_vod()` is an async iterator:

```python
info = await host.baichuan.get_vod_file_info(channel, file_id, stream)
async with aclosing(host.baichuan.download_vod(channel, file_id, info=info)) as chunks:
    async for chunk in chunks:
        ...
```

It works on both of my cameras.

## Why

On the Lumus Pro `cmd=Playback` answers with `video/x-flv`, so the integration
falls back to `cmd=Download` to get a real mp4. That fallback is the problem.

**`cmd=Download` is fragile.** It, and `cmd=Playback` with `output=`, make the
camera prepare a temporary file on the SD card. On my Lumus Pro that path can
leave recording playback dead until the camera is power cycled — at which point
the camera's own web UI can only show the live view either, so it is not
client-side. Its responses on this camera also intermittently carry a malformed,
empty-name header line right after `Content-Disposition`, which a strict parser
such as aiohttp rejects outright. My field notes on both are in
[home-assistant/core#147960 (comment)](https://github.com/home-assistant/core/issues/147960#issuecomment-5013173669).

**The streaming `cmd=Playback` response is not a substitute.** It does not make
the camera prepare a temporary file, but it is a live flv stream of unknown
length, so a consumer using it directly gets no total duration and no seeking.

That leaves a choice between fragile-but-seekable and safe-but-not-seekable.
Baichuan is neither: the camera reports the exact file size up front and then
sends the stored mp4 as-is, with its `moov` atom at the front, without preparing
anything on the SD card. A consumer can serve that with a correct
`Content-Length` and answer range requests.

## Protocol

```
cmd_id 14  FileInfoList{searchAITrack,channelId,streamType,startTime,endTime}
                       -> handle
cmd_id 15  FileInfoList{channelId,searchAITrack,handle}
                       -> the recordings in that window, each with name, an
                          absolute Id, sizeL/sizeH, fileType, containsAudio
cmd_id 16  same body   -> close the search
cmd_id 13  FileInfoList{Id,channelId[,name]}
                       -> handle, sizeL/sizeH, fileType, containsAudio
cmd_id  8  same body   -> push messages carrying the file as payload
cmd_id  9  FileInfoList{channelId,handle} -> release the VOD session
```

`get_vod_file_info()` searches a one second window around the recording's own
start time, which returns a single entry rather than a day's worth, and falls
back to `cmd_id` 13 when it cannot: the file name carries no usable timestamp, or
the stream is one Baichuan has no known name for.

Details that are not obvious:

* **The search is what supplies the path.** `cmd_id` 13's answer carries no `Id`,
  `cmd_id` 15's listing does, and the two are not always the same — see Model
  support.
* **`cmd_id` 14 alone is not enough.** Its answer carries the handle and nothing
  else; the recordings come from `cmd_id` 15.
* **The search only answers for one stream.** Asking `mainStream` for a sub
  stream recording returns nothing, and asking `subStream` for a main stream one
  returns the sub recording of the same moment, which starts a second earlier.
  The entry is matched on `<name>` so that one is rejected.
* **There is no terminator for `cmd_id` 8.** The camera simply stops sending, so
  completion is determined by comparing the received length against `sizeL`.
* **`cmd_id` 9 needs a body.** An empty one is answered with status 400;
  `channelId` alone is accepted. The handle from `cmd_id` 13 is sent as well
  because that is what the camera hands back, but both of my cameras return `0`
  for it, so I cannot show that a different value is honoured. It is sent from a
  `finally` block because the camera only has one VOD session, which also means
  stopping the iterator early still releases it.
* **Payload chunks carry `<encryptLen>`**, which `_push_callback` already
  decrypts, so nothing extra was needed there.

## API shape

`download_vod()` is an async iterator rather than following the existing
`send_payload()` pattern. Two reasons.

**`send_payload()` cannot be reused here.** It completes when a message arrives
carrying a zero length payload, and `cmd_id` 8 never sends one — the transfer just
ends once the reported size has arrived. Its two current users, `cmd_id` 109
(snapshot) and 298 (CoverPreview), depend on that terminator.

**Returning `bytes` does not scale to recordings.** Those two users fetch images.
One 30 s 4K recording here is 17 MB, delivered as 521 chunks of roughly 33 KB, and
longer clips are a multiple of that. Buffering a whole recording in memory is a
lot to ask of the hardware Home Assistant often runs on.

A synchronous callback was my first attempt and I would advise against it. The
callback is invoked from the event loop, so every consumer has to bridge it to
whatever actually writes the data, and both obvious bridges are wrong:

* a **bounded** thread queue deadlocks the event loop if the writer ever stops
  early. That is not theoretical — mine stopped when the cache file could not be
  opened, and after the queue filled (256 chunks, about 8 MB, well within a
  17 MB recording) `Queue.put` blocked the loop with nothing left to drain it;
* an **unbounded** queue removes the deadlock but moves the problem to memory.

An async iterator gives the consumer backpressure for free, and `aclosing()` makes
an early exit release the camera's single VOD session deterministically, which I
verified by breaking out mid transfer and then downloading the same file again.

Internally the chunks are handed over on a **bounded** `asyncio.Queue`. The camera
pushes data whether or not the consumer keeps up, so an unbounded queue would let a
slow or stalled disk accumulate a whole recording in memory. Instead the transfer
fails once the queue is full, since dropping a chunk would corrupt the file, and
the consumer can fall back to whatever it did before. A deliberately slow consumer
raises that error and a normal download of the same recording still succeeds
afterwards, so the session is released properly on that path too.

`get_vod_file_info()` returns a `VOD_file_info` named tuple, alongside the
existing `Parsed_VOD_file_name` and `VOD_download`.

## Model support

Tested on two cameras. They report their recording paths differently through the
same `Search` command — `/mnt/sda/Mp4Record/...` on the Lumus Pro,
`Mp4Record/...` on the E1 Zoom — and `cmd_id` 8 only accepts the absolute form:

| | Lumus Pro `v3.2.0.4243` | E1 Zoom `v3.1.0.4417` |
|---|---|---|
| `cmd_id` 8 with the path the caller was given | works | **status 400** |
| `cmd_id` 8 with the path from the `cmd_id` 15 listing | works | works |

This is why the search runs first: the camera's own listing is the authoritative
source for the path, and prefixing `/mnt/sda/` would be a guess from a sample of
two. Separately, the E1 Zoom answers `cmd_id` 13 and 8 with status 400 unless
`<name>` accompanies the `<Id>`, so it is added whenever the start timestamp can
be read from the file name and left out when it cannot.

Two limits worth stating. Baichuan names its streams differently from the rest of
the API, and only `main` and `sub` are known to translate — `get_vod_source` maps
`autotrack_*` and `telephoto_*` onto their own stream numbers, so they are
separate streams rather than variants. Learning what Baichuan calls them needs a
camera that records them, which I do not have, so those skip the search and are
left to `cmd_id` 13, which works wherever the caller's path is already the one the
camera wants. And a channel is only remembered as refusing downloads when it
rejects a path the camera itself reported; a rejected caller path says nothing
about the camera.

## Relationship to #164

#164 is a larger PR — VOD browsing, replay streaming and live streaming — and the
two are complementary rather than competing.

* **Reading a recording.** #164's `stream_recording_bc` is for `baichuan_only`
  cameras where HTTP download is unavailable. It yields
  `(microseconds, video_bytes, codec)` frames over the replay protocol
  (MSG 5/8/0x17d) through a BcMedia parser, which a consumer still has to mux and
  which has no total length, so no seeking. This PR is for the opposite case —
  HTTP is available but harmful (the Lumus Pro's `cmd=Download`) or not seekable
  — and asks for the **stored file**, receiving the mp4 byte for byte with its
  size known up front.
* **File search.** This is where they touch: #164 uses `cmd_id` 142/14/15 for
  day-level listing, this PR uses 14/15/16 to resolve one recording's path. Same
  command family, different question — which days have recordings versus a single
  file's `<Id>`. If #164 lands first they could share that layer; I have kept
  this PR self contained so it does not depend on that.

This PR was worked out by capturing the traffic of Reolink's own published CLI
against my camera (see Provenance below), not by decompiling anything.

## Related pull request

[home-assistant/core#177436](https://github.com/home-assistant/core/pull/177436)
is the Home Assistant side that consumes this, and it **depends on this PR**: it
cannot bump its pinned `reolink-aio`, and so cannot be merged, until this is
released. Both were developed and tested together against the same two cameras.

## Validation

Against both cameras on the LAN:

* Downloads are **byte identical across runs** and match the same recording
  fetched independently.
* `ffprobe` reads them as normal seekable mp4s.
* The search costs about what the `cmd_id` 13 it replaces did: 368 ms against
  298 ms on the Lumus Pro, 232 ms against 105 ms on the E1 Zoom, because the
  window returns a single entry rather than the whole day.
* **Stopping the iterator early** releases the session cleanly; a subsequent
  download of the same recording still completes and matches.
* Works on a **freshly power cycled camera with no priming at all**, which is the
  case that leaves the HTTP playback handler dead on the Lumus Pro.
* On the E1 Zoom, which refuses the caller's relative path, the download over the
  searched path is byte identical to what Reolink's own CLI produces for the same
  recording.
* `black`, `isort`, `flake8`, `pylint` (10.00/10) and `mypy` are all clean. The
  only change to existing code is two import lines.

## Provenance

The protocol was worked out by capturing the LAN traffic of [Reolink's own
officially published CLI](https://github.com/reolink/reolink-cli) talking to my
camera, decoding it with this library's existing header parsing and crypto
helpers, and then verifying every field by direct experimentation on both
cameras. Which fields are actually required, the `cmd_id` 9 body requirement,
the completion rule and the per-model differences above all come from that
experimentation.

No vendor code was decompiled and nothing was copied from a proprietary source.
