### PR TITLE
Query bc_webhook support directly instead of gating on the webhook ability bit

### DIFF
--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -1788,7 +1788,7 @@ class Baichuan:
             self.capabilities[None].add("sync_time")
 
         self.http_api._is_battery = not self.http_api.is_nvr and self.api_version("battery", 0) > 0
-        if (self.api_version("webhook") >> 1) & 1 and self.http_api.is_battery:
+        if self.http_api.is_battery:
             host_coroutines.append((806, self.send(cmd_id=806)))
 
         if host_coroutines:


### PR DESCRIPTION
## Summary

`get_host_data()` only queries `cmd_id 806` (whether a device supports the Baichuan webhook push subscription) when bit 1 of the device-reported `webhook` ability is set:

```python
if (self.api_version("webhook") >> 1) & 1 and self.http_api.is_battery:
    host_coroutines.append((806, self.send(cmd_id=806)))
```

That bit doesn't reliably reflect real support. On my Reolink Video Doorbell (firmware `v3.0.0.6304_26041428`), diagnostics show `BC_abilities.Host.webhook: 1` — bit 1 unset — so the query is skipped entirely, `bc_webhook` is never registered, and the integration falls back to polling with:

```
Baichuan host x.x.x.x: Battery model 'Reolink Video Doorbell', firmware v3.0.0.6304_26041428 does not support webhooks, no motion/AI push updates
```

The same symptom is reported in home-assistant/core#175653 for a Reolink TrackMix PTZ WiFi Battery, so this isn't specific to one model.

## Fix

Drop the ability-bit pre-check and just send `cmd_id 806` for every battery-class device, letting the camera answer for itself instead of guessing from an unreliable bit:

```diff
 self.http_api._is_battery = not self.http_api.is_nvr and self.api_version("battery", 0) > 0
-if (self.api_version("webhook") >> 1) & 1 and self.http_api.is_battery:
+if self.http_api.is_battery:
     host_coroutines.append((806, self.send(cmd_id=806)))
```

This is safe for devices that genuinely don't support the subscription: `cmd_id 806` failures are already caught a few lines below via `isinstance(result, ReolinkError): continue`, so those devices just get one harmless extra query at setup and the existing warning still fires. Devices that do support it — but were previously being filtered out by the bit check — now get to prove it.

## Testing

Ran with this change against my own Reolink Video Doorbell: `cmd_id 806` now succeeds, `bc_webhook` gets registered, the warning no longer appears, and `binary_sensor.*_person`/`*_motion` update immediately from real events instead of via polling.

I didn't find existing unit test coverage for this branch of `get_host_data()`; happy to add a test if you can point me at the right fixture pattern for Baichuan ability responses.

Related: home-assistant/core#175653