### PR TITLE
Add two-way audio (talk) support over Baichuan

### DIFF
--- a/reolink_aio/baichuan/adpcm.py
+++ b/reolink_aio/baichuan/adpcm.py
@@ -1,0 +1,84 @@
+"""IMA/DVI4 ADPCM encoding for Reolink two-way audio (talk)
+
+Reolink cameras only accept ADPCM audio for the talk feature, framed in
+BcMedia packets. The block layout is the standard IMA ADPCM one: a 4 byte
+header with the predictor state, followed by one nibble per sample.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterable
+
+BCMEDIA_ADPCM_MAGIC = 0x62773130
+BCMEDIA_ADPCM_DATA_MAGIC = 0x0100
+BCMEDIA_PAD_SIZE = 8
+
+STEP_TABLE = (
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41,
+    45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190,
+    209, 230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658, 724,
+    796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272,
+    2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132,
+    7845, 8630, 9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500,
+    20350, 22385, 24623, 27086, 29794, 32767,
+)
+INDEX_TABLE = (-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8)
+
+
+class AdpcmEncoder:
+    """IMA/DVI4 ADPCM encoder, the predictor state runs across blocks."""
+
+    def __init__(self) -> None:
+        self.predictor = 0
+        self.index = 0
+
+    def _encode_sample(self, sample: int) -> int:
+        step = STEP_TABLE[self.index]
+        diff = sample - self.predictor
+        nibble = 0
+        if diff < 0:
+            nibble = 8
+            diff = -diff
+
+        delta = step >> 3
+        if diff >= step:
+            nibble |= 4
+            diff -= step
+            delta += step
+        if diff >= step >> 1:
+            nibble |= 2
+            diff -= step >> 1
+            delta += step >> 1
+        if diff >= step >> 2:
+            nibble |= 1
+            delta += step >> 2
+
+        self.predictor += -delta if nibble & 8 else delta
+        self.predictor = max(-32768, min(32767, self.predictor))
+        self.index = max(0, min(len(STEP_TABLE) - 1, self.index + INDEX_TABLE[nibble]))
+        return nibble
+
+    def encode_block(self, samples: Iterable[int]) -> bytes:
+        """Encode one ADPCM block: 4 byte header followed by the nibbles"""
+        samples = list(samples)
+        block = bytearray(struct.pack("<hBB", self.predictor, self.index, 0))
+        for i in range(0, len(samples), 2):
+            low = self._encode_sample(samples[i])
+            high = self._encode_sample(samples[i + 1]) if i + 1 < len(samples) else 0
+            block.append((high << 4) | low)
+        return bytes(block)
+
+
+def bcmedia_adpcm_packet(block: bytes) -> bytes:
+    """Wrap an ADPCM block in a BcMedia packet, padded to 8 bytes"""
+    size = len(block) + 4  # data + 2 byte magic + 2 byte block size
+    packet = struct.pack(
+        "<IHHHH",
+        BCMEDIA_ADPCM_MAGIC,
+        size,
+        size,
+        BCMEDIA_ADPCM_DATA_MAGIC,
+        (len(block) - 4) // 2,  # block size without the header, halved
+    ) + block
+    return packet + b"\x00" * (-len(packet) % BCMEDIA_PAD_SIZE)

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Iterable, Sequence
 from datetime import datetime, timedelta
 from inspect import getmembers
 from time import time as time_now
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Coroutine, Literal, overload
 from xml.etree import ElementTree as XML
 
@@ -87,6 +86,8 @@ _LOGGER = logging.getLogger(__name__)
 KEEP_ALLIVE_INTERVAL = 30  # seconds
 MIN_KEEP_ALLIVE_INTERVAL = 9  # seconds
 BATTERY_CLOSE_TIME = 5  # seconds
+TALK_LEAD = 0.2  # seconds of two-way audio the camera may have buffered ahead
+TALK_MAX_BACKLOG = 0.5  # seconds of two-way audio that may be sent in one burst
 
 AI_DETECTS = {"people", "vehicle", "dog_cat", "state"}
 SMART_AI = {
@@ -3170,12 +3171,43 @@ class Baichuan:
         get_talk_ability (16 kHz on all known models). The audio is sent in
         real time, so this coroutine takes as long as the audio is long.
 
+        Use talk_stream to play audio that does not exist yet when the session
+        starts, a live microphone for example.
+
         Only one talk session can be active at a time, on an NVR that limit
         applies to all channels together, not per channel. When another client
         is already talking, ApiError with rspCode 422 is raised. A session that
         was never closed, after a crash for example, is released by the camera
         as soon as the connection is gone, so it does not need to be reset.
         """
+        talk_ability = await self._start_talk(channel, talk_ability)
+        try:
+            samples_per_block = talk_ability.length_per_encoder
+            blocks = (pcm[start : start + samples_per_block] for start in range(0, len(pcm), samples_per_block))
+            await self._send_talk_audio(channel, blocks, talk_ability)
+        finally:
+            await self.talk_stop(channel)
+
+    async def talk_stream(self, channel: int, audio: AsyncIterator[bytes], talk_ability: TalkAbility | None = None) -> None:
+        """Play a stream of 16 bit little endian mono PCM through the speaker
+
+        Meant for audio that arrives while it is being played, a microphone in
+        a voice call for example. The chunks may have any size, they do not
+        have to line up with the block size of the encoder. The session runs
+        until the stream ends, so stop the stream to hang up.
+
+        The audio is paced to real time. When it arrives faster than that, for
+        instance from a file, sending waits, and when it arrives slower the
+        camera simply plays what it gets. Everything else works like talk().
+        """
+        talk_ability = await self._start_talk(channel, talk_ability)
+        try:
+            await self._send_talk_audio(channel, self._blocks_from_stream(audio, talk_ability), talk_ability)
+        finally:
+            await self.talk_stop(channel)
+
+    async def _start_talk(self, channel: int, talk_ability: TalkAbility | None) -> TalkAbility:
+        """Look up the audio format if needed and open a talk session"""
         if talk_ability is None:
             talk_ability = self._talk_ability.get(channel) or await self.get_talk_ability(channel)
         if talk_ability is None:
@@ -3192,29 +3224,42 @@ class Baichuan:
             sound_track=talk_ability.sound_track,
         )
 
-        async with self._talk_lock:
-            try:
-                await self.send(cmd_id=201, channel=channel, body=xml)
-            except ApiError as err:
-                if err.rspCode != 422:
-                    raise
-                # 422 means another client is talking. Sending a talk stop to
-                # take the session over does interrupt their audio and gets
-                # refused again anyway while they keep streaming, so report it
-                # instead of fighting over the speaker.
-                raise ApiError(
-                    f"Baichuan host {self._host}: can not start two-way audio on channel {channel}, "
-                    "another client is already talking",
-                    rspCode=422,
-                ) from err
+        try:
+            await self.send(cmd_id=201, channel=channel, body=xml)
+        except ApiError as err:
+            if err.rspCode != 422:
+                raise
+            # 422 means another client is talking. Sending a talk stop to take
+            # the session over does interrupt their audio and gets refused
+            # again anyway while they keep streaming, so report it instead of
+            # fighting over the speaker.
+            raise ApiError(
+                f"Baichuan host {self._host}: can not start two-way audio on channel {channel}, "
+                "another client is already talking",
+                rspCode=422,
+            ) from err
 
-            try:
-                await self._send_talk_audio(channel, pcm, talk_ability)
-            finally:
-                await self.talk_stop(channel)
+        return talk_ability
 
-    async def _send_talk_audio(self, channel: int, pcm: Sequence[int], talk_ability: TalkAbility) -> None:
-        """Encode PCM to ADPCM and stream it to the camera in real time"""
+    @staticmethod
+    async def _blocks_from_stream(audio: AsyncIterator[bytes], talk_ability: TalkAbility) -> AsyncIterator[Sequence[int]]:
+        """Cut a stream of PCM bytes into blocks of the size the encoder wants"""
+        block_bytes = talk_ability.length_per_encoder * 2  # 16 bit samples
+        buffer = bytearray()
+        async for chunk in audio:
+            buffer += chunk
+            while len(buffer) >= block_bytes:
+                yield memoryview(bytes(buffer[:block_bytes])).cast("h")
+                del buffer[:block_bytes]
+
+        rest = len(buffer) - len(buffer) % 2  # a split sample can not be played
+        if rest:
+            yield memoryview(bytes(buffer[:rest])).cast("h")
+
+    async def _send_talk_audio(
+        self, channel: int, blocks: Iterable[Sequence[int]] | AsyncIterator[Sequence[int]], talk_ability: TalkAbility
+    ) -> None:
+        """Encode blocks of PCM to ADPCM and send them to the camera in real time"""
         encoder = AdpcmEncoder()
         extension = xmls.TALK_BINARY_EXTENSION_XML.format(channel=channel)
         ext_bytes = extension.encode("utf8")
@@ -3225,16 +3270,13 @@ class Baichuan:
         self._mess_id = (((self._mess_id >> 8) + 1) % 65536) << 8
         mess_id_bytes = (channel + 1).to_bytes(1, byteorder="little") + (self._mess_id).to_bytes(3, byteorder="little")
 
-        samples_per_block = talk_ability.length_per_encoder
-        block_duration = samples_per_block / talk_ability.sample_rate
-        next_send = self._loop.time()
-
         await self._connect_if_needed()
         if TYPE_CHECKING:
             assert self._connection is not None
 
-        for start in range(0, len(pcm), samples_per_block):
-            payload = bcmedia_adpcm_packet(encoder.encode_block(pcm[start : start + samples_per_block]))
+        next_send = self._loop.time()
+        async for block in _aiter(blocks):
+            payload = bcmedia_adpcm_packet(encoder.encode_block(block))
             mess_len = len(ext_bytes) + len(payload)
             header = (
                 bytes.fromhex(HEADER_MAGIC)
@@ -3246,11 +3288,18 @@ class Baichuan:
             )
             await self._connection.send_without_wait(header + enc_ext_bytes + payload, cmd_id=202)
 
-            # keep real time pacing without drifting
-            next_send += block_duration
-            delay = next_send - self._loop.time()
-            if delay > 0:
-                await asyncio.sleep(delay)
+            # Hold back audio that arrives faster than it plays, and send it
+            # right away when it arrives slower, which is what a microphone
+            # does. The camera is allowed to run TALK_LEAD ahead so that it
+            # always has something to play: waiting on every single block
+            # would let the rounding of each sleep add up to a stutter.
+            next_send += len(block) / talk_ability.sample_rate
+            ahead = next_send - self._loop.time()
+            if ahead > TALK_LEAD:
+                await asyncio.sleep(ahead - TALK_LEAD)
+            elif ahead < -TALK_MAX_BACKLOG:
+                # a source that fell behind should not earn a burst later
+                next_send = self._loop.time() - TALK_MAX_BACKLOG
 
     @http_cmd("GetMask")
     async def GetMask(self, channel: int, **_kwargs) -> None:
@@ -4569,3 +4618,13 @@ class Baichuan:
 
     def audio_noise_reduction(self, channel: int) -> int | None:
         return self._noise_reduction.get(channel)
+
+
+async def _aiter(blocks):
+    """Iterate over blocks that come either from a plain or an async iterable"""
+    if hasattr(blocks, "__aiter__"):
+        async for block in blocks:
+            yield block
+    else:
+        for block in blocks:
+            yield block

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from inspect import getmembers
 from time import time as time_now
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Coroutine, Literal, overload
 from xml.etree import ElementTree as XML
 
@@ -52,13 +53,14 @@ from ..exceptions import (
     UnexpectedDataError,
 )
 from ..software_version import SoftwareVersion
-from ..typings import VOD_file, VOD_trigger, cmd_list_type
+from ..typings import VOD_file, VOD_trigger, TalkAbility, cmd_list_type
 from ..utils import (
     datetime_to_reolink_time,
     reolink_time_to_datetime,
     to_reolink_time_id,
 )
 from . import xmls
+from .adpcm import AdpcmEncoder, bcmedia_adpcm_packet
 from .tcp_protocol import BaichuanTcpConnection
 from .udp_protocol import BaichuanUdpConnection
 from .util import (
@@ -153,6 +155,8 @@ class Baichuan:
         self._connection: BaichuanTcpConnection | BaichuanUdpConnection | None = None
         self.connection_type: ConnectionEnum = connection_type
         self._login_mutex = asyncio.Lock()
+        self._talk_lock = asyncio.Lock()
+        self._talk_ability: dict[int, TalkAbility] = {}
         self._loop = asyncio.get_event_loop()
         self._logged_in: bool = False
         self._login_sucess: bool = False
@@ -3124,6 +3128,115 @@ class Baichuan:
         await self.send(cmd_id=575, channel=channel, body=xml)
         # get the new privacy mode status
         await self.get_privacy_mode(channel)
+
+
+    async def get_talk_ability(self, channel: int = 0) -> TalkAbility | None:
+        """Get the audio format the camera accepts for two-way audio (talk)
+
+        Returns None if the channel does not support two-way audio.
+        """
+        try:
+            mess = await self.send(cmd_id=10, channel=channel)
+        except ReolinkError as err:
+            _LOGGER.debug("Baichuan host %s: no talk ability for channel %s: %s", self._host, channel, str(err))
+            return None
+
+        root = XML.fromstring(mess)
+        for audio_config in root.iter("audioConfig"):
+            if (audio_config.findtext("audioType") or "").strip() != "adpcm":
+                continue  # only ADPCM is implemented, cameras do not offer anything else
+            talk_ability = TalkAbility(
+                duplex=(root.findtext(".//duplex") or "FDX").strip(),
+                audio_stream_mode=(root.findtext(".//audioStreamMode") or "followVideoStream").strip(),
+                audio_type="adpcm",
+                sample_rate=int(audio_config.findtext("sampleRate") or 16000),
+                sample_precision=int(audio_config.findtext("samplePrecision") or 16),
+                length_per_encoder=int(audio_config.findtext("lengthPerEncoder") or 1024),
+                sound_track=(audio_config.findtext("soundTrack") or "mono").strip(),
+            )
+            self._talk_ability[channel] = talk_ability
+            return talk_ability
+
+        return None
+
+    async def talk_stop(self, channel: int = 0) -> None:
+        """Stop a running two-way audio (talk) session"""
+        await self.send(cmd_id=11, channel=channel)
+
+    async def talk(self, channel: int, pcm: Sequence[int], talk_ability: TalkAbility | None = None) -> None:
+        """Play 16 bit mono PCM audio through the speaker of a camera
+
+        The sample rate of the PCM data must match the sample rate from
+        get_talk_ability (16 kHz on all known models). The audio is sent in
+        real time, so this coroutine takes as long as the audio is long.
+        """
+        if talk_ability is None:
+            talk_ability = self._talk_ability.get(channel) or await self.get_talk_ability(channel)
+        if talk_ability is None:
+            raise InvalidParameterError(f"Baichuan host {self._host}: channel {channel} does not support two-way audio")
+
+        xml = xmls.TalkConfig.format(
+            channel=channel,
+            duplex=talk_ability.duplex,
+            audio_stream_mode=talk_ability.audio_stream_mode,
+            audio_type=talk_ability.audio_type,
+            sample_rate=talk_ability.sample_rate,
+            sample_precision=talk_ability.sample_precision,
+            length_per_encoder=talk_ability.length_per_encoder,
+            sound_track=talk_ability.sound_track,
+        )
+
+        async with self._talk_lock:
+            try:
+                await self.send(cmd_id=201, channel=channel, body=xml)
+            except ApiError:
+                # another client is talking, or a previous session was not closed
+                await self.talk_stop(channel)
+                await self.send(cmd_id=201, channel=channel, body=xml)
+
+            try:
+                await self._send_talk_audio(channel, pcm, talk_ability)
+            finally:
+                await self.talk_stop(channel)
+
+    async def _send_talk_audio(self, channel: int, pcm: Sequence[int], talk_ability: TalkAbility) -> None:
+        """Encode PCM to ADPCM and stream it to the camera in real time"""
+        encoder = AdpcmEncoder()
+        extension = xmls.TALK_BINARY_EXTENSION_XML.format(channel=channel)
+        ext_bytes = extension.encode("utf8")
+        enc_ext_bytes = self._aes_encrypt(ext_bytes)
+
+        # mess_id (3 bytes LE) is [stream_type][msg_num lo][msg_num hi], talk
+        # requires stream_type 0 so the lowest byte has to be zero
+        self._mess_id = (((self._mess_id >> 8) + 1) % 65536) << 8
+        mess_id_bytes = (channel + 1).to_bytes(1, byteorder="little") + (self._mess_id).to_bytes(3, byteorder="little")
+
+        samples_per_block = talk_ability.length_per_encoder
+        block_duration = samples_per_block / talk_ability.sample_rate
+        next_send = self._loop.time()
+
+        await self._connect_if_needed()
+        if TYPE_CHECKING:
+            assert self._connection is not None
+
+        for start in range(0, len(pcm), samples_per_block):
+            payload = bcmedia_adpcm_packet(encoder.encode_block(pcm[start : start + samples_per_block]))
+            mess_len = len(ext_bytes) + len(payload)
+            header = (
+                bytes.fromhex(HEADER_MAGIC)
+                + (202).to_bytes(4, byteorder="little")
+                + (mess_len).to_bytes(4, byteorder="little")
+                + mess_id_bytes
+                + bytes.fromhex("0000" + "1464")
+                + len(ext_bytes).to_bytes(4, byteorder="little")
+            )
+            await self._connection.send_without_wait(header + enc_ext_bytes + payload, cmd_id=202)
+
+            # keep real time pacing without drifting
+            next_send += block_duration
+            delay = next_send - self._loop.time()
+            if delay > 0:
+                await asyncio.sleep(delay)
 
     @http_cmd("GetMask")
     async def GetMask(self, channel: int, **_kwargs) -> None:

--- a/reolink_aio/baichuan/baichuan.py
+++ b/reolink_aio/baichuan/baichuan.py
@@ -3169,6 +3169,12 @@ class Baichuan:
         The sample rate of the PCM data must match the sample rate from
         get_talk_ability (16 kHz on all known models). The audio is sent in
         real time, so this coroutine takes as long as the audio is long.
+
+        Only one talk session can be active at a time, on an NVR that limit
+        applies to all channels together, not per channel. When another client
+        is already talking, ApiError with rspCode 422 is raised. A session that
+        was never closed, after a crash for example, is released by the camera
+        as soon as the connection is gone, so it does not need to be reset.
         """
         if talk_ability is None:
             talk_ability = self._talk_ability.get(channel) or await self.get_talk_ability(channel)
@@ -3189,10 +3195,18 @@ class Baichuan:
         async with self._talk_lock:
             try:
                 await self.send(cmd_id=201, channel=channel, body=xml)
-            except ApiError:
-                # another client is talking, or a previous session was not closed
-                await self.talk_stop(channel)
-                await self.send(cmd_id=201, channel=channel, body=xml)
+            except ApiError as err:
+                if err.rspCode != 422:
+                    raise
+                # 422 means another client is talking. Sending a talk stop to
+                # take the session over does interrupt their audio and gets
+                # refused again anyway while they keep streaming, so report it
+                # instead of fighting over the speaker.
+                raise ApiError(
+                    f"Baichuan host {self._host}: can not start two-way audio on channel {channel}, "
+                    "another client is already talking",
+                    rspCode=422,
+                ) from err
 
             try:
                 await self._send_talk_audio(channel, pcm, talk_ability)

--- a/reolink_aio/baichuan/xmls.py
+++ b/reolink_aio/baichuan/xmls.py
@@ -557,3 +557,27 @@ StartZoomFocus = """
 <movePos>{pos}</movePos>
 </StartZoomFocus>
 </body>"""
+
+TalkConfig = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<TalkConfig version="1.1">
+<channelId>{channel}</channelId>
+<duplex>{duplex}</duplex>
+<audioStreamMode>{audio_stream_mode}</audioStreamMode>
+<audioConfig>
+<audioType>{audio_type}</audioType>
+<sampleRate>{sample_rate}</sampleRate>
+<samplePrecision>{sample_precision}</samplePrecision>
+<lengthPerEncoder>{length_per_encoder}</lengthPerEncoder>
+<soundTrack>{sound_track}</soundTrack>
+</audioConfig>
+</TalkConfig>
+</body>"""
+
+TALK_BINARY_EXTENSION_XML = """<?xml version="1.0" encoding="UTF-8" ?>
+<Extension version="1.1">
+<channelId>{channel}</channelId>
+<binaryData>1</binaryData>
+</Extension>
+"""

--- a/reolink_aio/typings.py
+++ b/reolink_aio/typings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dtc
+from dataclasses import dataclass
 import logging
 from enum import IntFlag, auto
 from typing import (
@@ -334,6 +335,19 @@ VOD_download = NamedTuple(
         ("etag", Optional[str]),
     ],
 )
+
+
+@dataclass
+class TalkAbility:
+    """Audio format a camera accepts for two-way audio (talk)"""
+
+    duplex: str
+    audio_stream_mode: str
+    audio_type: str
+    sample_rate: int
+    sample_precision: int
+    length_per_encoder: int
+    sound_track: str
 
 
 class VOD_file:

--- a/tests/test_baichuan_talk.py
+++ b/tests/test_baichuan_talk.py
@@ -1,0 +1,222 @@
+"""Tests for two-way audio (talk), no camera needed"""
+
+from __future__ import annotations
+
+import math
+import struct
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from reolink_aio.baichuan.adpcm import (
+    INDEX_TABLE,
+    STEP_TABLE,
+    AdpcmEncoder,
+    bcmedia_adpcm_packet,
+)
+from reolink_aio.baichuan.baichuan import Baichuan
+from reolink_aio.exceptions import ApiError
+
+SAMPLE_RATE = 16000
+SAMPLES_PER_BLOCK = 1024
+
+TALK_ABILITY_XML = """<?xml version="1.0" encoding="UTF-8" ?>
+<body>
+<TalkAbility version="1.1">
+<duplexList><duplex>FDX</duplex></duplexList>
+<audioStreamModeList><audioStreamMode>followVideoStream</audioStreamMode></audioStreamModeList>
+<audioConfigList>
+<audioConfig>
+<priority>0</priority>
+<audioType>adpcm</audioType>
+<sampleRate>16000</sampleRate>
+<samplePrecision>16</samplePrecision>
+<lengthPerEncoder>1024</lengthPerEncoder>
+<soundTrack>mono</soundTrack>
+</audioConfig>
+</audioConfigList>
+</TalkAbility>
+</body>"""
+
+TALK_ABILITY_XML_NO_ADPCM = TALK_ABILITY_XML.replace("adpcm", "aac")
+
+
+def decode_adpcm_block(block: bytes) -> list[int]:
+    """Reference IMA ADPCM decoder, written from the spec, not from the encoder"""
+    predictor, index = struct.unpack("<hB", block[0:3])
+    samples = []
+    for byte in block[4:]:
+        for nibble in (byte & 0x0F, byte >> 4):  # low nibble holds the first sample
+            step = STEP_TABLE[index]
+            diff = step >> 3
+            if nibble & 4:
+                diff += step
+            if nibble & 2:
+                diff += step >> 1
+            if nibble & 1:
+                diff += step >> 2
+            predictor += -diff if nibble & 8 else diff
+            predictor = max(-32768, min(32767, predictor))
+            index = max(0, min(len(STEP_TABLE) - 1, index + INDEX_TABLE[nibble]))
+            samples.append(predictor)
+    return samples
+
+
+def sine(seconds: float, freq: float = 1000.0, amplitude: float = 0.8) -> list[int]:
+    return [int(amplitude * 32767 * math.sin(2 * math.pi * freq * i / SAMPLE_RATE)) for i in range(int(SAMPLE_RATE * seconds))]
+
+
+class TestAdpcm(unittest.TestCase):
+    def test_encodes_to_a_signal_a_reference_decoder_recognises(self) -> None:
+        original = sine(0.25)
+        encoder = AdpcmEncoder()
+        decoded: list[int] = []
+        for start in range(0, len(original), SAMPLES_PER_BLOCK):
+            decoded.extend(decode_adpcm_block(encoder.encode_block(original[start : start + SAMPLES_PER_BLOCK])))
+
+        self.assertEqual(len(decoded), len(original))
+        signal = sum(sample * sample for sample in original)
+        noise = sum((decoded[i] - original[i]) ** 2 for i in range(len(original)))
+        snr_db = 10 * math.log10(signal / noise)
+        self.assertGreater(snr_db, 20, f"ADPCM round trip only reached {snr_db:.1f} dB")
+
+    def test_block_holds_one_nibble_per_sample_plus_a_header(self) -> None:
+        block = AdpcmEncoder().encode_block(sine(0.064))  # exactly one block
+        self.assertEqual(len(block), 4 + SAMPLES_PER_BLOCK // 2)
+
+    def test_block_header_carries_the_state_the_block_starts_from(self) -> None:
+        # the predictor runs across blocks, so every header has to hold the
+        # state as it was before that block, otherwise a decoder drifts off
+        encoder = AdpcmEncoder()
+        samples = sine(0.192)
+
+        first = encoder.encode_block(samples[:SAMPLES_PER_BLOCK])
+        self.assertEqual(struct.unpack("<hBB", first[0:4])[0:2], (0, 0), "the first block starts from silence")
+
+        state_before = (encoder.predictor, encoder.index)
+        self.assertNotEqual(state_before, (0, 0), "encoding should have moved the state")
+        second = encoder.encode_block(samples[SAMPLES_PER_BLOCK : 2 * SAMPLES_PER_BLOCK])
+        predictor, index, _ = struct.unpack("<hBB", second[0:4])
+        self.assertEqual((predictor, index), state_before)
+
+    def test_bcmedia_packet_layout(self) -> None:
+        block = AdpcmEncoder().encode_block(sine(0.064))
+        packet = bcmedia_adpcm_packet(block)
+
+        magic, size, size_again, data_magic, block_size = struct.unpack("<IHHHH", packet[0:12])
+        self.assertEqual(magic, 0x62773130)
+        self.assertEqual(size, len(block) + 4)
+        self.assertEqual(size_again, size)
+        self.assertEqual(data_magic, 0x0100)
+        self.assertEqual(block_size, (len(block) - 4) // 2)
+        self.assertEqual(packet[12 : 12 + len(block)], block)
+        self.assertEqual(len(packet) % 8, 0, "BcMedia packets are padded to 8 bytes")
+
+
+class TestTalk(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.baichuan = Baichuan(
+            host="127.0.0.1",
+            username="user",
+            password="password",
+            http_api=SimpleNamespace(nvr_name="test", _updating=False),
+        )
+        self.baichuan._logged_in = True  # noqa: SLF001
+        self.baichuan._connect_if_needed = AsyncMock()  # type: ignore[method-assign]
+        self.baichuan._aes_encrypt = Mock(side_effect=lambda body: body)  # type: ignore[method-assign]
+
+        self.sent: list[tuple[int, str]] = []  # (cmd_id, body) of every command
+        self.audio: list[bytes] = []  # raw writes of the audio command
+        self.responses: dict[int, Exception | None] = {}
+
+        async def _send(cmd_id: int, channel=None, body: str = "", **kwargs) -> str:
+            self.sent.append((cmd_id, body))
+            error = self.responses.get(cmd_id)
+            if error is not None:
+                raise error
+            return TALK_ABILITY_XML if cmd_id == 10 else ""
+
+        self.baichuan.send = AsyncMock(side_effect=_send)  # type: ignore[method-assign]
+        self.baichuan._connection = SimpleNamespace(  # type: ignore[assignment]
+            send_without_wait=AsyncMock(side_effect=lambda data, cmd_id=None: self.audio.append(data))
+        )
+
+    async def test_get_talk_ability_reads_the_audio_format(self) -> None:
+        ability = await self.baichuan.get_talk_ability(2)
+
+        assert ability is not None
+        self.assertEqual(ability.audio_type, "adpcm")
+        self.assertEqual(ability.sample_rate, 16000)
+        self.assertEqual(ability.length_per_encoder, 1024)
+        self.assertEqual(ability.duplex, "FDX")
+        self.assertEqual(ability.sound_track, "mono")
+
+    async def test_get_talk_ability_without_adpcm_returns_none(self) -> None:
+        self.baichuan.send = AsyncMock(return_value=TALK_ABILITY_XML_NO_ADPCM)  # type: ignore[method-assign]
+
+        self.assertIsNone(await self.baichuan.get_talk_ability(2))
+
+    async def test_get_talk_ability_of_a_channel_without_speaker_returns_none(self) -> None:
+        self.baichuan.send = AsyncMock(side_effect=ApiError("not supported", rspCode=400))  # type: ignore[method-assign]
+
+        self.assertIsNone(await self.baichuan.get_talk_ability(1))
+
+    async def test_talk_starts_a_session_streams_audio_and_stops(self) -> None:
+        await self.baichuan.talk(2, sine(0.128))  # two blocks
+
+        commands = [cmd_id for cmd_id, _ in self.sent]
+        self.assertEqual(commands, [10, 201, 11], "expected ability, config and stop")
+        self.assertIn("<audioType>adpcm</audioType>", self.sent[1][1])
+        self.assertIn("<channelId>2</channelId>", self.sent[1][1])
+        self.assertEqual(len(self.audio), 2, "one command per ADPCM block")
+
+    async def test_audio_command_uses_stream_type_zero(self) -> None:
+        # mess_id (3 bytes LE) is [stream_type][msg_num lo][msg_num hi] and the
+        # camera silently drops the audio unless stream_type is zero
+        await self.baichuan.talk(2, sine(0.064))
+
+        written = self.audio[0]
+        self.assertEqual(int.from_bytes(written[4:8], byteorder="little"), 202)
+        self.assertEqual(written[12], 2 + 1, "channel id is the channel plus one")
+        self.assertEqual(written[13], 0, "stream type has to be zero for talk")
+
+    async def test_audio_payload_is_not_encrypted(self) -> None:
+        self.baichuan._aes_encrypt = Mock(side_effect=lambda body: b"\x00" * len(body))  # type: ignore[method-assign]
+
+        await self.baichuan.talk(2, sine(0.064))
+
+        written = self.audio[0]
+        payload_offset = int.from_bytes(written[20:24], byteorder="little")
+        payload = written[24 + payload_offset :]
+        self.assertEqual(int.from_bytes(payload[0:4], byteorder="little"), 0x62773130, "payload must stay raw BcMedia")
+
+    async def test_a_running_session_of_another_client_is_reported_not_taken_over(self) -> None:
+        self.responses[201] = ApiError("already talking", rspCode=422)
+
+        with self.assertRaises(ApiError) as caught:
+            await self.baichuan.talk(2, sine(0.064))
+
+        self.assertEqual(caught.exception.rspCode, 422)
+        self.assertIn("another client is already talking", str(caught.exception))
+        self.assertNotIn(11, [cmd_id for cmd_id, _ in self.sent], "must not stop the session of another client")
+        self.assertEqual(self.audio, [], "no audio may be sent when the session was refused")
+
+    async def test_other_errors_are_passed_through(self) -> None:
+        self.responses[201] = ApiError("bad request", rspCode=400)
+
+        with self.assertRaises(ApiError) as caught:
+            await self.baichuan.talk(2, sine(0.064))
+
+        self.assertEqual(caught.exception.rspCode, 400)
+
+    async def test_session_is_stopped_even_when_sending_audio_fails(self) -> None:
+        self.baichuan._connection.send_without_wait = AsyncMock(side_effect=OSError("connection lost"))
+
+        with self.assertRaises(OSError):
+            await self.baichuan.talk(2, sine(0.064))
+
+        self.assertIn(11, [cmd_id for cmd_id, _ in self.sent])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_baichuan_talk.py
+++ b/tests/test_baichuan_talk.py
@@ -209,6 +209,49 @@ class TestTalk(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(caught.exception.rspCode, 400)
 
+    async def test_talk_stream_plays_audio_that_arrives_in_chunks(self) -> None:
+        pcm = sine(0.128)  # two blocks
+        raw = struct.pack(f"<{len(pcm)}h", *pcm)
+
+        async def microphone():
+            for start in range(0, len(raw), 700):  # chunks that ignore block borders
+                yield raw[start : start + 700]
+
+        await self.baichuan.talk_stream(2, microphone())
+
+        self.assertEqual([cmd_id for cmd_id, _ in self.sent], [10, 201, 11])
+        self.assertEqual(len(self.audio), 2, "chunks are regrouped into whole blocks")
+
+    async def test_talk_stream_sends_a_trailing_partial_block(self) -> None:
+        pcm = sine(0.096)  # one and a half block
+        raw = struct.pack(f"<{len(pcm)}h", *pcm)
+
+        async def microphone():
+            yield raw
+
+        await self.baichuan.talk_stream(2, microphone())
+
+        self.assertEqual(len(self.audio), 2, "the remainder is played too")
+
+    async def test_talk_stream_ignores_a_split_sample_at_the_end(self) -> None:
+        async def microphone():
+            yield b"\x01"  # half a sample, nothing playable
+
+        await self.baichuan.talk_stream(2, microphone())
+
+        self.assertEqual(self.audio, [])
+        self.assertIn(11, [cmd_id for cmd_id, _ in self.sent], "session is still closed")
+
+    async def test_talk_stream_stops_the_session_when_the_stream_fails(self) -> None:
+        async def microphone():
+            yield struct.pack("<1024h", *sine(0.064))
+            raise OSError("microphone lost")
+
+        with self.assertRaises(OSError):
+            await self.baichuan.talk_stream(2, microphone())
+
+        self.assertIn(11, [cmd_id for cmd_id, _ in self.sent])
+
     async def test_session_is_stopped_even_when_sending_audio_fails(self) -> None:
         self.baichuan._connection.send_without_wait = AsyncMock(side_effect=OSError("connection lost"))
 


### PR DESCRIPTION

Reolink cameras support two-way audio, but only over the Baichuan protocol, so it is not reachable through this library today. This adds it for both standalone cameras and cameras behind an NVR, which is what makes the feature usable from Home Assistant, where two-way audio is currently listed as a known limitation.

### API

```python
ability = await host.baichuan.get_talk_ability(channel)   # None when unsupported

await host.baichuan.talk(channel, pcm)                    # a recording, 16 bit mono PCM
await host.baichuan.talk_stream(channel, audio)           # a live microphone
```

`get_talk_ability()` returns a `TalkAbility` describing the audio the channel accepts, so a caller can resample to the right rate and check support before offering the feature.

`talk()` takes a finished recording, which suits a message or a sound file. `talk_stream()` takes an async iterator of PCM bytes for audio that only exists while it is playing, a microphone in a voice call for example, and runs the session until the stream ends. Chunks may be any size; they are regrouped into the block size the encoder wants. Both share the session handling and the sender.

### How it works

`TalkAbility` (cmd 10) reports the accepted format, `TalkConfig` (cmd 201) starts a session, the audio goes out as BcMedia framed IMA/DVI4 ADPCM (cmd 202) and `TalkReset` (cmd 11) ends it. No video stream has to be running; starting one only adds around 3 seconds of latency.

Three details were not obvious and are worth pointing out for review:

* The `mess_id` field (3 bytes LE) is really `[stream_type][msg_num lo][msg_num hi]`. Talk needs `stream_type` 0, so the lowest byte has to be zero. With a non-zero value the camera acknowledges every packet with status 200 and plays nothing.
* The audio payload is raw BcMedia and must stay unencrypted, only the extension XML is encrypted.
* Only one talk session can be active at a time, and on an NVR that limit covers all channels together rather than one per channel.

### Pacing

The sender counts against a deadline rather than sleeping a fixed time per block, so a sleep that overshoots does not accumulate, and it lets the camera buffer up to `TALK_LEAD` ahead instead of waiting on every block, which would turn that rounding into a stutter. Audio arriving slower than real time is sent as it comes, so a microphone adds no latency of its own. Measured with the connection mocked: 6.00 s of audio sent in 5.81 s, median block interval 63.6 ms against 64.0 ms nominal.

### About the 422 handling

The first version answered a 422 the way the official client does, by sending a talk stop and trying again. Measuring the audio of the session that was already running showed what that costs. Against a control run without a second client, which had no interruption at all: a second login on its own interrupts the running audio for about 0.25 s, a refused `TalkConfig` for about 0.75 s, and the stop plus retry for about 1.5 s.

The retry also turned out to solve nothing. A session that was never closed, after a crash for example, is released by the camera as soon as the connection is gone, so there is nothing to reset. And a client that keeps streaming audio gets the retry refused as well. `talk()` therefore reports the 422 with a clear message and leaves the other client alone.

### Tests

`tests/test_baichuan_talk.py` adds 17 tests that need no camera: the ADPCM encoding against a reference decoder written from the spec, the BcMedia framing, reading the format from `TalkAbility`, the talk sequence itself, streaming with chunks that ignore block borders, and the 422 behaviour. Two of them guard the details above that nothing else would catch, since the camera answers 200 either way and simply stays silent.

Note that `tests/test_baichuan_utf8_length.py` already fails on `main` (it mocks `_aes_encrypt` with a `str` while the code passes `bytes`) — unrelated to this change, but it shows up when running the whole suite.

### Tested on hardware

An NVS8 (v3.6.0.384) with P330 cameras on channels 0, 2 and 3:

* Audio is played acoustically, not just accepted. A tone played on one camera was picked up both by that camera's own microphone and by a neighbouring camera in the same yard, while cameras further away recorded nothing. A human listener confirmed hearing it.
* The ADPCM encoder was checked against an independent reference decoder: 29.8 dB SNR.
* `get_talk_ability()` returns `None` on a channel without a speaker (an RLC-520 here) instead of raising.
* `talk_stream()` was driven from a live WebRTC microphone through go2rtc into a camera speaker.
* Starting a session while another one runs raises `ApiError` with rspCode 422 without disturbing the running audio; the channel is free again immediately afterwards.

One device behaviour worth knowing for callers: although `TalkAbility` reports `FDX`, the camera runs echo suppression that gates its microphone while speech is playing. Background noise survives a played tone at 89 % of its level, but during speech the microphone drops to near silence with short openings in the pauses. The NVR's own ONVIF service reports `SendPrimacy: HalfDuplex/Auto`, which matches. Nothing to fix in the library, but a caller cannot expect to hear the other side while talking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
