### PR TITLE
Fix stale session token used in stream/VOD URLs

### DIFF
--- a/reolink_aio/api.py
+++ b/reolink_aio/api.py
@@ -536,13 +536,15 @@ class Host:
     def protocol(self) -> str:
         return self._protocol
 
+    def _token_valid(self, margin_sec: int = 5) -> bool:
+        """Return True if a cached session token exists and has not yet expired."""
+        return self._token is not None and self._lease_time is not None and self._lease_time > (datetime.now() + timedelta(seconds=margin_sec))
+
     @property
     def session_active(self) -> bool:
         if self.baichuan_only:
             return self.baichuan.session_active
-        if self._token is not None and self._lease_time is not None and self._lease_time > (datetime.now() + timedelta(seconds=5)):
-            return True
-        return False
+        return self._token_valid(margin_sec=5)
 
     @property
     def timeout(self) -> float:
@@ -1323,7 +1325,7 @@ class Host:
             await self._login_try_ports()
             return  # succes
 
-        if self._token is not None and self._lease_time is not None and self._lease_time > (datetime.now() + timedelta(seconds=300)):
+        if self._token_valid(margin_sec=300):
             return  # succes
 
         # check privacy mode
@@ -1332,7 +1334,7 @@ class Host:
 
         await self._login_mutex.acquire()
         try:
-            if self._token is not None and self._lease_time is not None and self._lease_time > (datetime.now() + timedelta(seconds=300)):
+            if self._token_valid(margin_sec=300):
                 _LOGGER.debug(
                     "Host %s:%s, after login mutex aquired, login already completed by another coroutine",
                     self._host,
@@ -1662,6 +1664,32 @@ class Host:
     def clear_token(self) -> None:
         self._token = None
         self._lease_time = None
+
+    async def _ensure_valid_token(self, verify: bool = False) -> None:
+        """Ensure a non-expired session token is cached.
+
+        login() is a no-op when the lease is still valid, so this does not re-authenticate on every call.
+        When verify is True, also confirm the camera still accepts the token: stream URLs are fetched
+        outside of send() and cannot use the 'please login first' retry path.
+        """
+        if not self._token_valid(margin_sec=300):
+            try:
+                await self.login()
+            except LoginPrivacyModeError:
+                return
+        if not verify or not self._token_valid():
+            return
+        try:
+            # Cheap authenticated command so send() can expire+re-login if the camera already dropped the session.
+            await self.send([{"cmd": "GetDevInfo", "action": 0, "param": {}}], expected_response_type="json")
+        except ReolinkError as err:
+            _LOGGER.debug("Host %s:%s: session token check before building stream URL failed: %s", self._host, self._port, err)
+
+    def _stream_auth_query(self, prefer_token: bool) -> str:
+        """Return a stream/VOD auth query fragment that never embeds an expired token."""
+        if prefer_token and self._token_valid():
+            return f"token={self._token}"
+        return f"user={self._username}&password={self._password}"
 
     @property
     def capabilities(self) -> dict[int | None, dict[int | None, set[str]]]:
@@ -3361,14 +3389,9 @@ class Host:
             stream_type = 1
         else:
             stream_type = 0
-        if self._rtmp_auth_method == DEFAULT_RTMP_AUTH_METHOD:
-            # RTMP needs unencoded password
-            return (
-                f"rtmp://{self._host}:{self._rtmp_port}/bcs/"
-                f"channel{channel}_{stream}.bcs?channel={channel}&stream={stream_type}&user={self._username}&password={self._password}"
-            )
-
-        return f"rtmp://{self._host}:{self._rtmp_port}/bcs/channel{channel}_{stream}.bcs?channel={channel}&stream={stream_type}&token={self._token}"
+        # RTMP needs unencoded password. Never embed a stale/expired session token.
+        auth = self._stream_auth_query(prefer_token=self._rtmp_auth_method != DEFAULT_RTMP_AUTH_METHOD)
+        return f"rtmp://{self._host}:{self._rtmp_port}/bcs/channel{channel}_{stream}.bcs?channel={channel}&stream={stream_type}&{auth}"
 
     async def get_encoding(self, channel: int, stream: str = "main") -> str:
         if not self._enc_settings:
@@ -3523,6 +3546,8 @@ class Host:
         if stream not in ["main", "sub", "ext", "autotrack_sub", "autotrack_main", "telephoto_sub", "telephoto_main"]:
             return None
         if (self.protocol == "rtmp" or (stream == "ext" and not self.supported(None, "FLV"))) and not self.baichuan_only:
+            if self._rtmp_auth_method != DEFAULT_RTMP_AUTH_METHOD:
+                await self._ensure_valid_token(verify=True)
             return self.get_rtmp_stream_source(channel, stream)
         if (self.protocol == "flv" or stream in ["autotrack_sub", "telephoto_sub", "ext"]) and not self.baichuan_only:
             return self.get_flv_stream_source(channel, stream)
@@ -3567,7 +3592,9 @@ class Host:
             credentials = f"&user={self._username}&password={self._password}"
         else:
             mime = "video/mp4"
-            credentials = f"&token={self._token}"
+            # Playback/download URLs are fetched outside of send(), so confirm the token is still accepted.
+            await self._ensure_valid_token(verify=True)
+            credentials = f"&{self._stream_auth_query(prefer_token=True)}"
 
         if request_type == VodRequestType.NVR_DOWNLOAD:
             # prepare the file for downloading and overwrite the new filename

--- a/tests/test_stream_token.py
+++ b/tests/test_stream_token.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+from reolink_aio.api import DEFAULT_RTMP_AUTH_METHOD, Host
+from reolink_aio.enums import VodRequestType
+
+
+class TestStreamToken(unittest.IsolatedAsyncioTestCase):
+    """Session tokens must not be embedded in stream URLs after they expire or are invalidated."""
+
+    async def asyncSetUp(self) -> None:
+        self.host = Host(
+            host="192.168.1.10",
+            username="admin",
+            password="secret",
+            port=80,
+            use_https=False,
+            protocol="rtmp",
+            rtmp_auth_method="TOKEN",
+        )
+        self.host._stream_channels = [0]
+        self.host._rtmp_port = 1935
+        self.host._url = "http://192.168.1.10:80/cgi-bin/api.cgi"
+        self.login_http_calls = 0
+
+        async def fake_send(body, param=None, expected_response_type="json", retry=3):
+            cmd = ""
+            if body:
+                cmd = body[0].get("cmd", "")
+            if param:
+                cmd = param.get("cmd", cmd)
+            if cmd == "Login":
+                self.login_http_calls += 1
+                return [{"cmd": "Login", "code": 0, "value": {"Token": {"name": "fresh-token", "leaseTime": 3600}}}]
+            if cmd == "Logout":
+                return "ok"
+            return [{"cmd": cmd or "GetDevInfo", "code": 0, "value": {}}]
+
+        self.host.send = fake_send  # type: ignore[method-assign]
+
+    async def asyncTearDown(self) -> None:
+        session = self.host._aiohttp_session
+        if session is not None and not session.closed:
+            await session.close()
+
+    def _set_token(self, name: str, *, valid_for: timedelta | None = None, expired: bool = False) -> None:
+        self.host._token = name
+        if expired:
+            self.host._lease_time = datetime.now() - timedelta(seconds=5)
+        else:
+            self.host._lease_time = datetime.now() + (valid_for or timedelta(hours=1))
+
+    def test_token_valid_respects_lease_time(self) -> None:
+        self.assertFalse(self.host._token_valid())
+        self.assertFalse(self.host.session_active)
+
+        self._set_token("abc", valid_for=timedelta(hours=1))
+        self.assertTrue(self.host._token_valid())
+        self.assertTrue(self.host.session_active)
+
+        self._set_token("abc", expired=True)
+        self.assertFalse(self.host._token_valid())
+        self.assertFalse(self.host.session_active)
+
+    def test_rtmp_source_embeds_valid_token(self) -> None:
+        self._set_token("valid-token")
+        url = self.host.get_rtmp_stream_source(0)
+        self.assertIsNotNone(url)
+        self.assertIn("token=valid-token", url)
+        self.assertNotIn("password=", url)
+
+    def test_rtmp_source_does_not_embed_expired_token(self) -> None:
+        self._set_token("stale-token", expired=True)
+        url = self.host.get_rtmp_stream_source(0)
+        self.assertIsNotNone(url)
+        self.assertNotIn("stale-token", url)
+        self.assertNotIn("token=", url)
+        self.assertIn("user=admin", url)
+        self.assertIn("password=secret", url)
+
+    def test_rtmp_source_does_not_embed_token_after_expire_session_marker(self) -> None:
+        # expire_session() backdates the lease but keeps the cached token string.
+        self._set_token("stale-token")
+        self.host._lease_time = datetime.now() - timedelta(seconds=5)
+        url = self.host.get_rtmp_stream_source(0)
+        self.assertIsNotNone(url)
+        self.assertNotIn("stale-token", url)
+        self.assertIn("password=secret", url)
+
+    def test_rtmp_password_auth_never_uses_token(self) -> None:
+        self.host._rtmp_auth_method = DEFAULT_RTMP_AUTH_METHOD
+        self._set_token("valid-token")
+        url = self.host.get_rtmp_stream_source(0)
+        self.assertIsNotNone(url)
+        self.assertNotIn("token=", url)
+        self.assertIn("password=secret", url)
+
+    async def test_stream_source_refreshes_expired_token_via_login(self) -> None:
+        self._set_token("stale-token", expired=True)
+        url = await self.host.get_stream_source(0, "main", check=False)
+        self.assertIsNotNone(url)
+        self.assertGreaterEqual(self.login_http_calls, 1)
+        self.assertNotIn("stale-token", url)
+        self.assertIn("token=fresh-token", url)
+
+    async def test_stream_source_does_not_relogin_when_token_still_valid(self) -> None:
+        self._set_token("valid-token", valid_for=timedelta(hours=1))
+        url = await self.host.get_stream_source(0, "main", check=False)
+        self.assertIsNotNone(url)
+        self.assertEqual(self.login_http_calls, 0)
+        self.assertIn("token=valid-token", url)
+
+        url = await self.host.get_stream_source(0, "main", check=False)
+        self.assertEqual(self.login_http_calls, 0)
+        self.assertIn("token=valid-token", url)
+
+    async def test_stream_source_replaces_camera_invalidated_token(self) -> None:
+        """Camera dropped the session before lease expiry; verify path must not keep the stale token."""
+        self._set_token("stale-token", valid_for=timedelta(hours=1))
+
+        async def recovering_send(body, param=None, expected_response_type="json", retry=3):
+            cmd = ""
+            if body:
+                cmd = body[0].get("cmd", "")
+            if param:
+                cmd = param.get("cmd", cmd)
+            if cmd == "GetDevInfo":
+                # Simulate send() recovery: camera rejected the token, a new one was issued.
+                self.host._token = "fresh-token"
+                self.host._lease_time = datetime.now() + timedelta(hours=1)
+                return [{"cmd": "GetDevInfo", "code": 0, "value": {}}]
+            if cmd == "Login":
+                self.login_http_calls += 1
+                return [{"cmd": "Login", "code": 0, "value": {"Token": {"name": "fresh-token", "leaseTime": 3600}}}]
+            if cmd == "Logout":
+                return "ok"
+            return [{"cmd": cmd or "GetDevInfo", "code": 0, "value": {}}]
+
+        self.host.send = recovering_send  # type: ignore[method-assign]
+        url = await self.host.get_stream_source(0, "main", check=False)
+        self.assertIsNotNone(url)
+        self.assertEqual(self.login_http_calls, 0)
+        self.assertNotIn("stale-token", url)
+        self.assertIn("token=fresh-token", url)
+
+    async def test_vod_playback_does_not_embed_expired_token(self) -> None:
+        self._set_token("stale-token", expired=True)
+        _mime, url = await self.host.get_vod_source(0, "RecS01_20240101_120000_120200.mp4", request_type=VodRequestType.PLAYBACK)
+        self.assertGreaterEqual(self.login_http_calls, 1)
+        self.assertNotIn("stale-token", url)
+        self.assertIn("token=fresh-token", url)
+
+    async def test_vod_playback_uses_valid_token_without_relogin(self) -> None:
+        self._set_token("valid-token", valid_for=timedelta(hours=1))
+        _mime, url = await self.host.get_vod_source(0, "RecS01_20240101_120000_120200.mp4", request_type=VodRequestType.PLAYBACK)
+        self.assertEqual(self.login_http_calls, 0)
+        self.assertIn("token=valid-token", url)
+
+    async def test_ensure_valid_token_skips_login_when_lease_is_valid(self) -> None:
+        self._set_token("valid-token", valid_for=timedelta(hours=1))
+        self.host.login = AsyncMock(side_effect=AssertionError("login() should not re-authenticate"))  # type: ignore[method-assign]
+        await self.host._ensure_valid_token(verify=False)
+        self.host.login.assert_not_called()
+        self.assertEqual(self.host._token, "valid-token")


### PR DESCRIPTION
### Description

Fixes home-assistant/core#173535 ("Reolink is re-using expired token, generating a lot of http-login error").

Stream and VOD source URLs embedded `self._token` even after the camera had invalidated the session (e.g. reboot, max-session, firmware quirk), causing HTTP 401 "login attempt failed" errors. Since stream URLs are fetched outside of `send()`, the "please login first" recovery there never ran, so the stale token kept being used until some other command happened to trigger a re-login.

### Changes

- Add `Host._token_valid()` to centralize the token/lease check (used by `login()` and `session_active`).
- Add `Host._stream_auth_query()` so stream/VOD URLs only embed a token when it is still valid; otherwise they fall back to username/password.
- Add `Host._ensure_valid_token()` to re-login (or probe the camera with a cheap authenticated `GetDevInfo` command) before a token is embedded in a URL.
- Wire into `get_rtmp_stream_source` and `get_vod_source`.

### Tests

- Added `tests/test_stream_token.py` (11 tests) covering expired token, `expire_session`, camera-invalidated token, and "no extra login" cases.
- `pytest tests/ -q` -> 12 passed, 1 pre-existing unrelated failure (`test_baichuan_utf8_length.py`).

Fixes https://github.com/home-assistant/core/issues/173535